### PR TITLE
fix(research): clean up BibTeX — protected surname, semantic citekey, ResearchGate URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ identifiers:
   # doi / arxivId / researchGateId — fed into ScholarlyArticle.identifier
   researchGateId: '400103838'
 bibtex: |
-  @misc{annafee2025meshdecimation,
-    author = {An Nafee, Ahnaf},
+  @misc{annafee2025meshsimplification,
+    author = {Ahnaf {An Nafee}},
     title  = {…},
     year   = {2025}
   }

--- a/src/data/research/mesh-decimation-benchmark.mdx
+++ b/src/data/research/mesh-decimation-benchmark.mdx
@@ -63,14 +63,14 @@ links:
 identifiers:
   researchGateId: '400103838'
 bibtex: |
-  @misc{annafee2025meshdecimation,
-    author      = {An Nafee, Ahnaf},
+  @misc{annafee2025meshsimplification,
+    author      = {Ahnaf {An Nafee}},
     title       = {Performance Analysis of 3D Mesh Simplification Algorithms:
                    QEM vs. Vertex Clustering on CAD and Organic Models},
     year        = {2025},
     institution = {George Mason University},
     note        = {CS700 Course Project},
-    url         = {https://github.com/ahnafnafee/mesh-decimation-benchmark}
+    url         = {https://www.researchgate.net/publication/400103838_Performance_Analysis_of_3D_Mesh_Simplification_Algorithms_QEM_vs_Vertex_Clustering_on_CAD_and_Organic_Models}
   }
 related: []
 ---


### PR DESCRIPTION
Tiny follow-up to #101 — three small BibTeX corrections, kept consistent between the actual entry and the README example.

## Changes

| Field | Before | After | Why |
|---|---|---|---|
| `author` | `{An Nafee, Ahnaf}` | `{Ahnaf {An Nafee}}` | Brace-protect "An Nafee" so BibTeX/LaTeX treats it as one indivisible surname unit. The comma form is ambiguous — some styles parse "Ahnaf" as a middle name and reflow as "Nafee, A.A." |
| citekey | `annafee2025meshdecimation` | `annafee2025meshsimplification` | Matches the paper's actual title language ("3D Mesh Simplification Algorithms") rather than the colloquial repo name. Distinguishes from any future decimation-only work. |
| `url` | `github.com/ahnafnafee/mesh-decimation-benchmark` | ResearchGate publication 400103838 | GitHub is the code mirror; the citation should point at the publication of record. |

## Files

- `src/data/research/mesh-decimation-benchmark.mdx` — frontmatter `bibtex`
- `README.md` — research-frontmatter example, kept in sync