### PR TITLE
feat(og): always use dynamic mesh card for article OG meta

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -12,6 +12,11 @@ import type { OgPageType } from '@/libs/og/og-types'
 export const runtime = 'nodejs'
 
 const PROFILE_URL = 'https://ik.imagekit.io/8ieg70pvks/profile?tr=w-560,h-560'
+// Hard cap on the profile fetch at module-load. Without this, a slow
+// ImageKit response would stall every concurrent request for the lifetime
+// of the stall (the existing .catch() only handles hard rejections, not
+// hung connections).
+const PROFILE_FETCH_TIMEOUT_MS = 3000
 
 const MONO_REGULAR_PATH = fileURLToPath(new URL('./fonts/JetBrainsMono-Regular.ttf', import.meta.url))
 const MONO_BOLD_PATH = fileURLToPath(new URL('./fonts/JetBrainsMono-Bold.ttf', import.meta.url))
@@ -31,7 +36,10 @@ function detectMime(bytes: Uint8Array): string {
 // shows an "AN" initials fallback when profileSrc is empty).
 const profileDataUrl: Promise<string> = (async () => {
   try {
-    const res = await fetch(PROFILE_URL, { redirect: 'follow' })
+    const res = await fetch(PROFILE_URL, {
+      redirect: 'follow',
+      signal: AbortSignal.timeout(PROFILE_FETCH_TIMEOUT_MS)
+    })
     if (!res.ok) return ''
     const buf = Buffer.from(await res.arrayBuffer())
     return `data:${detectMime(buf)};base64,${buf.toString('base64')}`

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -39,15 +39,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   try {
     const res = await getContentBySlug<Blog>('/blog', slug)
     const header = res.header
-    const ogImage =
-      header.thumbnail ||
-      generateOgImage({
-        title: header.title,
-        subTitle: header.summary,
-        type: 'blog-post',
-        topics: header.topics,
-        theme: 'dark'
-      })
+    // Always render the dynamic mesh-hero card for og:image — the in-site
+    // listing card on /blog continues to use header.thumbnail directly via
+    // BlogItem.tsx, so the raw thumbnail still appears where it makes sense
+    // (1:1 / 5:4 listing slots) without competing with the OG card chrome.
+    const ogImage = generateOgImage({
+      title: header.title,
+      subTitle: header.summary,
+      type: 'blog-post',
+      topics: header.topics,
+      theme: 'dark'
+    })
     const modifiedTime = header.updated || header.published
     const canonical = `${SITE_URL}/blog/${header.slug}`
     const seeAlso = (header.related ?? []).map((s) => `${SITE_URL}/blog/${s}`)
@@ -113,15 +115,13 @@ export default async function BlogPost({ params }: Props) {
     const stats = readingTime(res.content)
     const est_read = stats.text
     const header = { est_read, ...res.header }
-    const ogImage =
-      header.thumbnail ||
-      generateOgImage({
-        title: header.title,
-        subTitle: header.summary,
-        type: 'blog-post',
-        topics: header.topics,
-        theme: 'dark'
-      })
+    const ogImage = generateOgImage({
+      title: header.title,
+      subTitle: header.summary,
+      type: 'blog-post',
+      topics: header.topics,
+      theme: 'dark'
+    })
     const dateModified = header.updated || header.published
     const keywordsList = header.keywords?.filter(Boolean) ?? []
     const adjacent = getAdjacentPosts(slug, allPosts)

--- a/src/app/meta/blog/route.ts
+++ b/src/app/meta/blog/route.ts
@@ -27,15 +27,13 @@ function generateMetaHtml(post: {
   topics?: string[]
 }): string {
   const canonicalUrl = `${SITE_URL}/blog/${post.slug}`
-  const ogImage =
-    post.thumbnail ||
-    generateOgImage({
-      title: post.title,
-      subTitle: post.summary,
-      type: 'blog-post',
-      topics: post.topics,
-      theme: 'dark'
-    })
+  const ogImage = generateOgImage({
+    title: post.title,
+    subTitle: post.summary,
+    type: 'blog-post',
+    topics: post.topics,
+    theme: 'dark'
+  })
 
   const safeTitle = escapeHtml(post.title)
   const safeSummary = escapeHtml(post.summary)

--- a/src/app/research/[slug]/page.tsx
+++ b/src/app/research/[slug]/page.tsx
@@ -44,10 +44,12 @@ const formatVenue = (venue: Research['venue']): string | undefined => {
   return label || (venue.year ? String(venue.year) : undefined)
 }
 
+// og:image always uses the dynamic mesh-hero card so social-share previews
+// stay cohesive across every research entry. `header.thumbnail` and
+// `header.teaser` continue to drive the in-site listing card and the
+// detail-page hero figure (via ResearchItem / ResearchTeaser), so the raw
+// images still appear where they actually fit the layout.
 const resolveOgImage = (header: Research): string => {
-  if (header.ogImage) return header.ogImage
-  if (header.teaser) return header.teaser
-  if (header.thumbnail) return header.thumbnail
   return generateOgImage({
     title: header.title,
     subTitle: header.summary,


### PR DESCRIPTION
## Why

PR #109 shipped a polygon-mesh hero card, but article pages with a custom thumbnail / teaser short-circuited it — the `og:image` meta still returned the raw image, so social-share previews showed two visual languages (mesh-hero for index pages, raw photos for posts). Twitter / LinkedIn audiences who saw consistent branded cards for the home or `/research` index then got a different aesthetic clicking through to a specific post.

## What changes

`og:image` now always renders the dynamic mesh card. The raw thumbnail / teaser / portfolio image continues to drive the **in-site listing card** (via `BlogItem.tsx` and `ResearchItem.tsx` — both untouched in this PR) and the **detail-page hero figure** (`ResearchTeaser` — also untouched). Each image lives where it composes well; the OG meta is now always the branded card.

| Surface | Source (unchanged) |
|---|---|
| Listing card on `/blog`, `/research`, `/portfolio` | raw `header.thumbnail` / `header.teaser` / `header.image` via `BlogItem.tsx`, `ResearchItem.tsx`, `PortfolioItem.tsx` |
| Detail-page hero figure on a research post | `header.teaser` via `ResearchTeaser` |
| **`og:image` meta tag in `<head>` for the post page** | **always `generateOgImage(...)` (this PR)** |

### Files changed

- `src/app/blog/[slug]/page.tsx` — drop the `header.thumbnail \|\| generateOgImage(...)` short-circuit (2 places)
- `src/app/research/[slug]/page.tsx:resolveOgImage` — drop the `ogImage > teaser > thumbnail > generated` priority chain
- `src/app/meta/blog/route.ts` — drop the same short-circuit in the SEO HTML meta route
- `src/app/api/og/route.tsx` — add `AbortSignal.timeout(3000)` to the module-load profile fetch (closes the open code-review item from #109; a slow ImageKit response would otherwise stall every concurrent request)

Listing-card resolvers are explicitly untouched. Portfolio's `generateMetadata` was already always-generate (no override pattern existed) so that file isn't in the diff.

## Backdrop variant — explored, rejected

A `?image=` param + faded-backdrop layer was prototyped and rendered against real thumbnails. Most existing thumbnails are themselves cover images with the article title baked in, so layering the mesh card on top duplicated the title text. The "raw image stays a thumbnail, dynamic card is the OG" split is the cleaner outcome and avoids per-thumbnail visual-clash debugging.

## Test plan

- [x] `yarn vitest run` — 60 / 60 pass
- [x] `yarn type-check` — exit 0
- [x] `yarn lint` — clean
- [x] `npx tsx scripts/generate-banner-og.tsx --all` — 11 mesh-only PNGs render successfully
- [ ] **Manual after deploy:** run an article URL through [opengraph.xyz](https://www.opengraph.xyz) and confirm the dynamic card renders (not the raw thumbnail)
- [ ] **Manual after deploy:** confirm the in-site `/blog` and `/research` listing cards still show the original photos (no regression)

## Cache invalidation

`generateOgImage` keys off `VERCEL_GIT_COMMIT_SHA`, so the merge SHA automatically invalidates every cached `og:image` URL. No manual `NEXT_PUBLIC_OG_VERSION` bump needed.