### PR TITLE
fix(og): minimal article cards, no overflow on long titles

### DIFF
--- a/src/libs/og/og-shell.tsx
+++ b/src/libs/og/og-shell.tsx
@@ -19,9 +19,9 @@ import {
   OG_SIZE,
   OG_TYPE_LABEL
 } from './og-tokens'
-import { AuthorLine, GradientTitle, MetaText, Subtitle, TopicChip, TypeChip } from './og-typography'
+import { AuthorLine, GradientTitle, MetaText, Subtitle, TITLE_HIDE_TOPICS_THRESHOLD, TopicChip, TypeChip } from './og-typography'
 
-import type { OgAccent, OgCardProps } from './og-types'
+import type { OgAccent, OgCardProps, OgPageType } from './og-types'
 
 const MESH_LAYOUT = {
   width: 820,
@@ -29,6 +29,16 @@ const MESH_LAYOUT = {
   top: -90,
   left: -140,
   opacity: 0.2
+}
+
+// Article (*-post) cards are intentionally minimal — title is hero, no
+// summary paragraph, fewer topic chips. Listing / index pages keep the
+// summary because their titles are short and the canvas would feel empty.
+const ARTICLE_TOPIC_CAP = 3
+const LISTING_TOPIC_CAP = 5
+
+function isArticleType(type: OgPageType): boolean {
+  return type === 'blog-post' || type === 'portfolio-post' || type === 'research-post'
 }
 
 function Avatar({ src, accent }: { src: string; accent: OgAccent }) {
@@ -116,7 +126,20 @@ function VenueLine({ accent, venue }: { accent: OgAccent; venue: string }) {
 export function OgCard(props: OgCardProps) {
   const accent = OG_ACCENTS[props.type]
   const typeLabel = OG_TYPE_LABEL[props.type]
-  const topics = (props.topics ?? []).slice(0, 5).filter((t) => t && t.trim().length > 0)
+  const isArticle = isArticleType(props.type)
+  const topicCap = isArticle ? ARTICLE_TOPIC_CAP : LISTING_TOPIC_CAP
+  // Drop topics on article cards whose title falls into the 50px (long-tail)
+  // bucket — the title alone fills the center band at that tier, and a
+  // topics row would push the last title line off-canvas.
+  const titleIsLongTier = isArticle && (props.title?.length ?? 0) > TITLE_HIDE_TOPICS_THRESHOLD
+  const topics = titleIsLongTier
+    ? []
+    : (props.topics ?? []).filter((t) => t && t.trim().length > 0).slice(0, topicCap)
+  // Article cards drop the subtitle entirely — at OG scan distance, a
+  // 200-char abstract paragraph is unreadable and just steals space from
+  // the title (which is the actual hook). The <meta name="description">
+  // still carries the full summary for SEO consumers.
+  const showSubtitle = !isArticle && Boolean(props.subtitle)
 
   return (
     <div
@@ -199,13 +222,13 @@ export function OgCard(props: OgCardProps) {
               height: 4,
               width: 96,
               backgroundColor: accent.rule,
-              marginTop: 22,
-              marginBottom: props.subtitle ? 22 : 18,
+              marginTop: 24,
+              marginBottom: showSubtitle ? 22 : 26,
               borderRadius: 2
             }}
           />
 
-          {props.subtitle ? <Subtitle>{props.subtitle}</Subtitle> : null}
+          {showSubtitle ? <Subtitle>{props.subtitle!}</Subtitle> : null}
 
           {topics.length > 0 ? (
             <div
@@ -213,7 +236,7 @@ export function OgCard(props: OgCardProps) {
                 display: 'flex',
                 flexWrap: 'wrap',
                 gap: 10,
-                marginTop: props.subtitle ? 22 : 8
+                marginTop: showSubtitle ? 22 : 0
               }}
             >
               {topics.map((topic) => (

--- a/src/libs/og/og-typography.tsx
+++ b/src/libs/og/og-typography.tsx
@@ -10,27 +10,54 @@ import { OG_FG, OG_FG_MUTED, OG_FONT_FAMILY } from './og-tokens'
 
 import type { OgAccent } from './og-types'
 
-const TITLE_MAX_CHARS = 110
-const TITLE_ELLIPSIS_AT = 108
-
+// Title sizing via empirical length buckets.
+//
+// Earlier iterations computed chars-per-line from `fontSize * 0.6` (raw
+// monospace advance). That underestimated word-wrap losses for long titles —
+// the picker thought 110 chars fit in 4 lines at 60px, but they actually
+// wrapped to 5 lines and the last one was clipped. These buckets are tuned
+// against the empirical wrap of JetBrains Mono Bold at 1056px content width,
+// with each `maxLen` chosen so the rendered title stays inside the ~270px
+// center-band budget on article cards (subtitle dropped).
 type TitleSize = { fontSize: number; lineHeight: number }
 
-function pickTitleSize(length: number): TitleSize {
-  if (length <= 24) return { fontSize: 78, lineHeight: 1.04 }
-  if (length <= 38) return { fontSize: 66, lineHeight: 1.06 }
-  if (length <= 56) return { fontSize: 54, lineHeight: 1.1 }
-  if (length <= 80) return { fontSize: 44, lineHeight: 1.14 }
-  return { fontSize: 38, lineHeight: 1.16 }
+// Center-band budget is ~286px (1200×630 canvas minus 60+56 padding, 32
+// top-chip row, and the 148px avatar cap). Each bucket caps `maxLen` so the
+// rendered title + rule + (optional topics row) stays inside that budget.
+// Long titles (50px tier) trigger og-shell.tsx to drop the topics row,
+// which buys the title the full center band.
+const TITLE_BUCKETS: ReadonlyArray<{ maxLen: number; size: TitleSize }> = [
+  { maxLen: 18, size: { fontSize: 92, lineHeight: 1.04 } },
+  { maxLen: 32, size: { fontSize: 80, lineHeight: 1.06 } },
+  { maxLen: 50, size: { fontSize: 70, lineHeight: 1.08 } },
+  { maxLen: 78, size: { fontSize: 60, lineHeight: 1.1 } },
+  { maxLen: 130, size: { fontSize: 50, lineHeight: 1.16 } }
+]
+
+// The title-length threshold at which og-shell hides the topics row to give
+// the 50px tier the full center band. Tied to the 50px bucket's lower bound
+// (matches TITLE_BUCKETS[3].maxLen).
+export const TITLE_HIDE_TOPICS_THRESHOLD = 78
+
+function chooseTitleSize(textLength: number): { size: TitleSize; capChars: number } {
+  for (const bucket of TITLE_BUCKETS) {
+    if (textLength <= bucket.maxLen) return { size: bucket.size, capChars: bucket.maxLen }
+  }
+  // Anything beyond the last bucket renders at the smallest size with hard
+  // truncation so it still fits cleanly.
+  const last = TITLE_BUCKETS[TITLE_BUCKETS.length - 1]
+  return { size: last.size, capChars: last.maxLen }
 }
 
-function clampTitle(text: string): string {
-  if (text.length <= TITLE_MAX_CHARS) return text
-  return text.slice(0, TITLE_ELLIPSIS_AT).trimEnd() + '…'
+function clampToCap(text: string, capChars: number): string {
+  if (text.length <= capChars) return text
+  return text.slice(0, Math.max(0, capChars - 1)).trimEnd() + '…'
 }
 
 export function GradientTitle({ children, accent }: { children: string; accent: OgAccent }) {
-  const display = clampTitle(children)
-  const { fontSize, lineHeight } = pickTitleSize(display.length)
+  const raw = children ?? ''
+  const { size, capChars } = chooseTitleSize(raw.length)
+  const display = clampToCap(raw, capChars)
   const stops = accent.titleStops.join(', ')
 
   return (
@@ -38,10 +65,10 @@ export function GradientTitle({ children, accent }: { children: string; accent: 
       style={{
         display: 'flex',
         fontFamily: OG_FONT_FAMILY.sans,
-        fontSize,
+        fontSize: size.fontSize,
         fontWeight: 800,
         letterSpacing: '-0.025em',
-        lineHeight,
+        lineHeight: size.lineHeight,
         backgroundImage: `linear-gradient(135deg, ${stops})`,
         backgroundClip: 'text',
         color: 'transparent',
@@ -56,7 +83,7 @@ export function GradientTitle({ children, accent }: { children: string; accent: 
 }
 
 export function Subtitle({ children }: { children: string }) {
-  const text = children.length > 180 ? children.slice(0, 178).trimEnd() + '…' : children
+  const text = children.length > 140 ? children.slice(0, 138).trimEnd() + '…' : children
   return (
     <div
       style={{


### PR DESCRIPTION
## Summary
- Article OG cards (`*-post`) now drop the subtitle entirely — at OG scan distance, a 200-char abstract paragraph is unreadable and just steals space from the title (the actual hook).
- Title sizing replaced with empirical length buckets (calibrated against the ~286px center-band budget after the 148px avatar cap). Floor is 50px so even the longest research titles stay bold; short titles get a 92px hero treatment.
- Topics capped at 3 on article cards; auto-hidden when the title falls into the 50px (long-tail) bucket so the title gets the full center band without clipping.
- Listing / index cards (`home`, `blog`, `portfolio`, `research`, `resume`, `page`) keep their subtitle since their short titles need the supporting line.

### Before vs after for the failing case
The 110-char research title (`Performance Analysis of 3D Mesh Simplification Algorithms: QEM vs. Vertex Clustering on CAD and Organic Models`) was rendering at ~38px with the last line `Organic Models` clipped behind the rule + chips. It now renders at 50px / 4 lines fully visible, no topic chips, clean.

### Title-size buckets
| Title length | Font | Lines | Topics |
| --- | --- | --- | --- |
| ≤18 chars | 92px | 1 | 3 chips |
| ≤32 chars | 80px | 2 | 3 chips |
| ≤50 chars | 70px | 2 | 3 chips |
| ≤78 chars | 60px | 3 | 3 chips |
| 79–130 chars | 50px | 4 | hidden |
| >130 chars | 50px (hard-truncate) | 4 | hidden |

## Test plan
- [x] `yarn type-check` clean
- [x] `yarn lint` clean
- [x] `yarn test --run` — 60/60 pass
- [x] Rendered `/api/og` for the 110-char research title, a 67-char blog title, a 46-char blog title, an 8-char portfolio title, and the `Blog` listing page — all visually clean, no clipping
- [ ] Inspect the Vercel preview deployment's `/api/og?type=research-post&title=...` to confirm production parity with local renders

## Files touched
- `src/libs/og/og-typography.tsx` — replace formula-based picker with empirical length buckets; export `TITLE_HIDE_TOPICS_THRESHOLD` constant
- `src/libs/og/og-shell.tsx` — add `isArticleType()` helper, drop subtitle and cap topics for article variants, hide topics when title is in the 50px tier