### PR TITLE
feat(home): spider-verse glitch burst on hero name

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -256,6 +256,7 @@ export default async function HomePage() {
               <h1
                 className='name-aberration mb-3 bg-gradient-to-br from-primary-600 via-purple-600 to-pink-500 bg-clip-text text-5xl font-extrabold tracking-tight text-transparent md:text-7xl dark:from-primary-300 dark:via-purple-300 dark:to-pink-300'
                 itemProp='name'
+                data-text={'Ahnaf An Nafee'}
               >
                 Ahnaf <span className='whitespace-nowrap'>An Nafee</span>
               </h1>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -98,8 +98,22 @@
    * (cyan +1 to the right, magenta -1 to the left) sit underneath the gradient
    * text fill — barely perceptible but adds a hint of comic-book character.
    * Both light and dark modes use the same offsets; the alphas are tuned so
-   * the effect is visible without dominating the gradient. */
+   * the effect is visible without dominating the gradient.
+   *
+   * Spider-Verse glitch: a ~1 s burst fires every 8 s on top of the calm
+   * baseline. The keyframes use `steps(1, end)` so each frame holds — hard
+   * cuts read like a glitched film cell, not a smooth tween. Three layers
+   * play simultaneously during the burst:
+   *   1. The main h1 — chromatic text-shadow (up to ±12 px) plus skew,
+   *      jitter, and a brief hue-rotate filter.
+   *   2. `::before` — cyan top-half slice that flashes in and tracks
+   *      horizontally opposite to `::after`.
+   *   3. `::after` — magenta bottom-half slice mirroring `::before`.
+   * Wrapped in `prefers-reduced-motion: no-preference` so motion-sensitive
+   * users get the static chromatic baseline only (declarations outside the
+   * media query stay as the fallback). */
   .name-aberration {
+    position: relative;
     text-shadow:
       1px 0 0 rgba(0, 200, 255, 0.35),
       -1px 0 0 rgba(255, 80, 160, 0.3);
@@ -109,6 +123,239 @@
     text-shadow:
       2px 0 0 rgba(0, 234, 255, 0.4),
       -2px 0 0 rgba(255, 100, 200, 0.32);
+  }
+
+  /* Pseudo-element slices for the Spider-Verse character split. They are
+   * absolutely positioned over the h1, take their text from `data-text`,
+   * and use a solid color (no bg-clip-text) so the slice reads as a
+   * comic-book "ghost" pass. Opacity 0 by default; only the keyframes
+   * inside the prefers-reduced-motion guard make them visible. */
+  .name-aberration::before,
+  .name-aberration::after {
+    content: attr(data-text);
+    position: absolute;
+    inset: 0;
+    font: inherit;
+    font-weight: inherit;
+    letter-spacing: inherit;
+    background: none;
+    -webkit-text-fill-color: currentColor;
+    pointer-events: none;
+    opacity: 0;
+    will-change: transform, opacity;
+  }
+
+  .name-aberration::before {
+    color: rgba(0, 234, 255, 0.9);
+    clip-path: polygon(0 0, 100% 0, 100% 48%, 0 48%);
+  }
+
+  .name-aberration::after {
+    color: rgba(255, 80, 200, 0.9);
+    clip-path: polygon(0 52%, 100% 52%, 100% 100%, 0 100%);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .name-aberration {
+      animation: name-glitch-light 8s steps(1, end) infinite;
+      /* translate3d on the keyframes promotes the element to its own
+       * compositor layer, keeping the burst on the GPU. */
+      will-change: transform, text-shadow, filter;
+    }
+
+    .dark .name-aberration {
+      animation: name-glitch-dark 8s steps(1, end) infinite;
+    }
+
+    .name-aberration::before {
+      animation: name-slice-top 8s steps(1, end) infinite;
+    }
+
+    .name-aberration::after {
+      animation: name-slice-bottom 8s steps(1, end) infinite;
+    }
+
+    @keyframes name-glitch-light {
+      0%,
+      85%,
+      99%,
+      100% {
+        text-shadow:
+          1px 0 0 rgba(0, 200, 255, 0.35),
+          -1px 0 0 rgba(255, 80, 160, 0.3);
+        transform: translate3d(0, 0, 0);
+        filter: none;
+      }
+      86% {
+        text-shadow:
+          10px 0 0 rgba(0, 234, 255, 0.95),
+          -10px 0 0 rgba(255, 80, 200, 0.9),
+          0 4px 0 rgba(255, 240, 100, 0.6),
+          0 -4px 0 rgba(120, 255, 100, 0.4);
+        transform: translate3d(-3px, 1px, 0) skewX(1deg);
+        filter: contrast(1.1) saturate(1.2);
+      }
+      88% {
+        text-shadow:
+          -12px 0 0 rgba(0, 234, 255, 0.95),
+          12px 0 0 rgba(255, 80, 200, 0.9),
+          0 -3px 0 rgba(255, 240, 100, 0.5);
+        transform: translate3d(3px, -1px, 0) skewX(-1.5deg);
+        filter: hue-rotate(18deg) contrast(1.15);
+      }
+      90% {
+        text-shadow:
+          8px 0 0 rgba(0, 234, 255, 0.85),
+          -8px 0 0 rgba(255, 80, 200, 0.85);
+        transform: translate3d(-2px, 0, 0) skewX(0.5deg);
+        filter: hue-rotate(-12deg);
+      }
+      92% {
+        text-shadow:
+          -6px 0 0 rgba(0, 234, 255, 0.75),
+          6px 0 0 rgba(255, 80, 200, 0.75),
+          0 2px 0 rgba(255, 240, 100, 0.4);
+        transform: translate3d(2px, 0, 0);
+        filter: none;
+      }
+      94% {
+        text-shadow:
+          4px 0 0 rgba(0, 234, 255, 0.6),
+          -4px 0 0 rgba(255, 80, 200, 0.6);
+        transform: translate3d(-1px, 0, 0);
+      }
+      96% {
+        text-shadow:
+          2px 0 0 rgba(0, 234, 255, 0.45),
+          -2px 0 0 rgba(255, 80, 200, 0.45);
+        transform: translate3d(1px, 0, 0);
+      }
+    }
+
+    @keyframes name-glitch-dark {
+      0%,
+      85%,
+      99%,
+      100% {
+        text-shadow:
+          2px 0 0 rgba(0, 234, 255, 0.4),
+          -2px 0 0 rgba(255, 100, 200, 0.32);
+        transform: translate3d(0, 0, 0);
+        filter: none;
+      }
+      86% {
+        text-shadow:
+          12px 0 0 rgba(0, 234, 255, 1),
+          -12px 0 0 rgba(255, 100, 220, 0.95),
+          0 4px 0 rgba(255, 240, 100, 0.65),
+          0 -4px 0 rgba(140, 255, 120, 0.45);
+        transform: translate3d(-3px, 1px, 0) skewX(1.2deg);
+        filter: contrast(1.15) saturate(1.25);
+      }
+      88% {
+        text-shadow:
+          -14px 0 0 rgba(0, 234, 255, 1),
+          14px 0 0 rgba(255, 100, 220, 0.95),
+          0 -3px 0 rgba(255, 240, 100, 0.55);
+        transform: translate3d(3px, -1px, 0) skewX(-1.8deg);
+        filter: hue-rotate(20deg) contrast(1.2);
+      }
+      90% {
+        text-shadow:
+          10px 0 0 rgba(0, 234, 255, 0.9),
+          -10px 0 0 rgba(255, 100, 220, 0.9);
+        transform: translate3d(-2px, 0, 0) skewX(0.6deg);
+        filter: hue-rotate(-14deg);
+      }
+      92% {
+        text-shadow:
+          -7px 0 0 rgba(0, 234, 255, 0.8),
+          7px 0 0 rgba(255, 100, 220, 0.8),
+          0 2px 0 rgba(255, 240, 100, 0.45);
+        transform: translate3d(2px, 0, 0);
+        filter: none;
+      }
+      94% {
+        text-shadow:
+          5px 0 0 rgba(0, 234, 255, 0.65),
+          -5px 0 0 rgba(255, 100, 220, 0.65);
+        transform: translate3d(-1px, 0, 0);
+      }
+      96% {
+        text-shadow:
+          3px 0 0 rgba(0, 234, 255, 0.5),
+          -3px 0 0 rgba(255, 100, 220, 0.5);
+        transform: translate3d(1px, 0, 0);
+      }
+    }
+
+    @keyframes name-slice-top {
+      0%,
+      85%,
+      99%,
+      100% {
+        opacity: 0;
+        transform: translate3d(0, 0, 0);
+      }
+      86% {
+        opacity: 1;
+        transform: translate3d(10px, -1px, 0);
+      }
+      88% {
+        opacity: 0.95;
+        transform: translate3d(-8px, 1px, 0);
+      }
+      90% {
+        opacity: 0.85;
+        transform: translate3d(6px, 0, 0);
+      }
+      92% {
+        opacity: 0.6;
+        transform: translate3d(-4px, 0, 0);
+      }
+      94% {
+        opacity: 0.35;
+        transform: translate3d(2px, 0, 0);
+      }
+      96% {
+        opacity: 0;
+        transform: translate3d(0, 0, 0);
+      }
+    }
+
+    @keyframes name-slice-bottom {
+      0%,
+      85%,
+      99%,
+      100% {
+        opacity: 0;
+        transform: translate3d(0, 0, 0);
+      }
+      86% {
+        opacity: 1;
+        transform: translate3d(-10px, 1px, 0);
+      }
+      88% {
+        opacity: 0.95;
+        transform: translate3d(8px, -1px, 0);
+      }
+      90% {
+        opacity: 0.85;
+        transform: translate3d(-6px, 0, 0);
+      }
+      92% {
+        opacity: 0.6;
+        transform: translate3d(4px, 0, 0);
+      }
+      94% {
+        opacity: 0.35;
+        transform: translate3d(-2px, 0, 0);
+      }
+      96% {
+        opacity: 0;
+        transform: translate3d(0, 0, 0);
+      }
+    }
   }
 
   .pattern {


### PR DESCRIPTION
## Summary

Upgrades the static cyan/magenta `.name-aberration` text-shadow on the home-page hero into a periodic, visually heavy Spider-Verse glitch.

- Every 8 s, a ~1 s burst fires with 7 step-frames (`steps(1, end)` so each frame holds — no smooth tween, gives the film-cell-cut feel).
- Main `<h1>` chromatic channels swing up to **±14 px** in dark mode (±12 px light), with brief `skewX`, `hue-rotate`, and `saturate` filter shifts on the peak frames.
- Two new pseudo-elements (`::before` cyan top half, `::after` magenta bottom half) flash in during the burst and translate horizontally opposite each other — that's the authentic Spider-Verse character-slice. They read their text from a new `data-text="Ahnaf An Nafee"` attribute on the `<h1>` via `content: attr(data-text)`, then `clip-path: polygon(...)` carves them in half.
- Entire animation block is gated by `@media (prefers-reduced-motion: no-preference)`, so motion-sensitive users still get the original static chromatic baseline as the fallback. This is the **codebase's first `prefers-reduced-motion` guard** — happy to land a broader audit in a follow-up if you want.

CSS-only — no new deps, no JS, no framer-motion. Compositor-friendly: `will-change: transform, text-shadow, filter` on the main h1, `will-change: transform, opacity` on the pseudos, and `translate3d` in every keyframe so the animation stays on the GPU.

## Burst timeline (per cycle)

| Frame | Time | Main `<h1>` | `::before` (cyan top) | `::after` (magenta bottom) |
| --- | --- | --- | --- | --- |
| 86% | 6.88 s | ±10-12 px channels + yellow/green accents, `skewX(1°)`, `contrast/saturate` bump | flash in at `+10 px, -1 px` | flash in at `-10 px, +1 px` |
| 88% | 7.04 s | ∓12-14 px flip, `skewX(-1.5°)`, **`hue-rotate(18°)`** | `-8 px, +1 px` | `+8 px, -1 px` |
| 90% | 7.20 s | ±8-10 px, `skewX(0.5°)`, `hue-rotate(-12°)` | `+6 px` | `-6 px` |
| 92% | 7.36 s | ∓6-7 px + yellow accent | `-4 px` | `+4 px` |
| 94% | 7.52 s | ±4-5 px | `+2 px` (fading) | `-2 px` (fading) |
| 96% | 7.68 s | ±2-3 px (near-calm flicker) | invisible | invisible |
| 0% / 99-100% | calm | original subtle ±1-2 px chromatic baseline | invisible | invisible |

## Files touched

- `src/app/page.tsx` — added `data-text={'Ahnaf An Nafee'}` to the hero `<h1>` (one-line attribute, no structural change).
- `src/styles/globals.css` — extended `.name-aberration` with `position: relative` + pseudo-element rules; added 4 keyframes (`name-glitch-light`, `name-glitch-dark`, `name-slice-top`, `name-slice-bottom`) inside a `prefers-reduced-motion: no-preference` guard.

## Test plan

- [x] `yarn type-check` clean
- [x] `yarn lint` clean
- [x] `yarn test --run` — 60/60 pass
- [x] Watched the home hero locally for ~20 s — observed two glitch bursts at the expected ~8 s cadence in both light and dark modes; slices visible
- [x] DevTools → Rendering → emulate `prefers-reduced-motion: reduce` → reload → animation gone, static baseline still present
- [ ] Inspect the Vercel preview build to confirm the served CSS is identical (especially the `attr(data-text)` resolution, which Turbopack and prod compilers occasionally treat differently)
- [ ] (Optional) DevTools Performance recording on `/` to confirm the burst stays on the compositor (no layout/paint thrash from `text-shadow` + `filter`)