### PR TITLE
fix(blog): modelfile syntax + quieter code-block chrome + drop prose backticks

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-dom": "19.2.1",
     "react-icons": "5.5.0",
     "react-image-lightbox": "^5.1.4",
+    "refractor": "^4.8.0",
     "rehype-katex": "^7.0.1",
     "rehype-prism-plus": "^2.0.1",
     "remark-gfm": "^4.0.1",

--- a/src/components/content/mdx/CodeBlockShell.tsx
+++ b/src/components/content/mdx/CodeBlockShell.tsx
@@ -52,21 +52,31 @@ export const CodeBlockShell = ({ language, children, className }: CodeBlockShell
     >
       <div
         className={twclsx(
-          'flex items-center justify-between',
+          'flex items-center justify-between gap-3',
           'border-b border-neutral-200/70 dark:border-neutral-800',
-          'bg-neutral-50/60 dark:bg-neutral-900/40',
-          'px-4 py-1.5'
+          'bg-neutral-100 dark:bg-neutral-900/60',
+          'px-3 py-2'
         )}
       >
-        <span
-          className={twclsx(
-            'font-mono text-[0.7rem] tracking-[0.08em] lowercase',
-            'text-neutral-500 dark:text-neutral-400',
-            'select-none'
-          )}
-        >
-          {language || 'text'}
-        </span>
+        <div className='flex items-center gap-2'>
+          {/* macOS-style window controls — purely decorative; the canonical
+            * close/minimize/zoom palette signals "this is a terminal-style
+            * surface" without taking the visual weight of an interactive UI. */}
+          <div className='flex items-center gap-1.5' aria-hidden='true'>
+            <span className='block size-3 rounded-full bg-[#ff5f57] ring-1 ring-black/10 dark:ring-white/5' />
+            <span className='block size-3 rounded-full bg-[#febc2e] ring-1 ring-black/10 dark:ring-white/5' />
+            <span className='block size-3 rounded-full bg-[#28c840] ring-1 ring-black/10 dark:ring-white/5' />
+          </div>
+          <span
+            className={twclsx(
+              'ml-1 font-mono text-[0.7rem] tracking-[0.08em] lowercase',
+              'text-neutral-500 dark:text-neutral-400',
+              'select-none'
+            )}
+          >
+            {language || 'text'}
+          </span>
+        </div>
         <Button
           variant='ghost'
           size='icon-sm'

--- a/src/components/content/mdx/CodeBlockShell.tsx
+++ b/src/components/content/mdx/CodeBlockShell.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+
+import { twclsx } from '@/libs/twclsx'
+
+import { useEffect, useRef, useState } from 'react'
+import { HiCheck, HiClipboardCopy } from 'react-icons/hi'
+
+interface CodeBlockShellProps {
+  /** Lowercase language label shown in the top-left chip (e.g. "modelfile", "bibtex"). */
+  language: string
+  /** Children rendered inside the body, typically a single `<pre>`. */
+  children: React.ReactNode
+  /** Optional className passed through to the outer wrapper. */
+  className?: string
+}
+
+/**
+ * Single-surface code-block chrome shared by the MDX `Pre` renderer and the
+ * standalone `ResearchBibTeX` citation card. Thin neutral border, quiet
+ * monospace language chip, ghost copy button — sits on `var(--prism-bg)` so
+ * the body inherits the same theme-aware surface as the rest of the prism
+ * palette.
+ */
+export const CodeBlockShell = ({ language, children, className }: CodeBlockShellProps) => {
+  const [isCopied, setIsCopied] = useState(false)
+  const bodyRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isCopied) return
+    const timer = setTimeout(() => setIsCopied(false), 1500)
+    return () => clearTimeout(timer)
+  }, [isCopied])
+
+  const copyToClipboard = async () => {
+    if (bodyRef.current && !isCopied) {
+      await navigator.clipboard.writeText(bodyRef.current.textContent ?? '')
+      setIsCopied(true)
+    }
+  }
+
+  return (
+    <div
+      className={twclsx(
+        'not-prose group relative my-6',
+        'overflow-hidden rounded-lg',
+        'border border-neutral-200 dark:border-neutral-800',
+        'bg-[var(--prism-bg)]',
+        className
+      )}
+    >
+      <div
+        className={twclsx(
+          'flex items-center justify-between',
+          'border-b border-neutral-200/70 dark:border-neutral-800',
+          'bg-neutral-50/60 dark:bg-neutral-900/40',
+          'px-4 py-1.5'
+        )}
+      >
+        <span
+          className={twclsx(
+            'font-mono text-[0.7rem] tracking-[0.08em] lowercase',
+            'text-neutral-500 dark:text-neutral-400',
+            'select-none'
+          )}
+        >
+          {language || 'text'}
+        </span>
+        <Button
+          variant='ghost'
+          size='icon-sm'
+          onClick={copyToClipboard}
+          aria-label='Copy code to clipboard'
+          className={twclsx(
+            'h-7 w-7',
+            'text-neutral-500 hover:text-neutral-900',
+            'dark:text-neutral-400 dark:hover:text-neutral-100',
+            'hover:bg-neutral-200/60 dark:hover:bg-neutral-700/40'
+          )}
+        >
+          {isCopied ? (
+            <HiCheck className='h-3.5 w-3.5 text-emerald-500' />
+          ) : (
+            <HiClipboardCopy className='h-3.5 w-3.5' />
+          )}
+        </Button>
+      </div>
+
+      <div ref={bodyRef}>{children}</div>
+    </div>
+  )
+}

--- a/src/components/content/mdx/Pre.tsx
+++ b/src/components/content/mdx/Pre.tsx
@@ -1,13 +1,11 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-
 import { twclsx } from '@/libs/twclsx'
 
+import { CodeBlockShell } from './CodeBlockShell'
 import { Mermaid } from './Mermaid'
 
 import { Children, isValidElement, Suspense, useEffect, useRef, useState } from 'react'
-import { HiCheck, HiClipboardCopy } from 'react-icons/hi'
 
 interface PreProps {
   children: React.ReactNode
@@ -105,92 +103,27 @@ function getLanguageFromChildren(children: React.ReactNode): string {
 }
 
 export const Pre = ({ children, className }: PreProps) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false)
-  const preRef = useRef<HTMLPreElement>(null)
-
   const language = getLanguageFromChildren(children) || extractLanguage(className)
 
-  // Hooks must always run in the same order — keep useEffect above any early
-  // return (rules-of-hooks). The effect is a no-op when isCopied stays false.
-  useEffect(() => {
-    if (!isCopied) return
-    const timer = setTimeout(() => setIsCopied(false), 1500)
-    return () => clearTimeout(timer)
-  }, [isCopied])
-
-  // If it's a mermaid block, use the MermaidCodeBlock wrapper
+  // If it's a mermaid block, defer to the dedicated wrapper.
   if (language.startsWith('mermaid')) {
     return <MermaidCodeBlock>{children}</MermaidCodeBlock>
   }
 
-  const copyToClipboard = async () => {
-    if (preRef.current && !isCopied) {
-      await navigator.clipboard.writeText(preRef.current.textContent as string)
-      setIsCopied(true)
-    }
-  }
-
-  const displayLanguage = language || 'text'
-
   return (
-    <div
-      className={twclsx(
-        'not-prose group relative my-6',
-        'overflow-hidden rounded-lg',
-        'border border-neutral-200 dark:border-neutral-800',
-        'bg-[var(--prism-bg)]'
-      )}
-    >
-      <div
-        className={twclsx(
-          'flex items-center justify-between',
-          'border-b border-neutral-200/70 dark:border-neutral-800',
-          'bg-neutral-50/60 dark:bg-neutral-900/40',
-          'px-4 py-1.5'
-        )}
-      >
-        <span
-          className={twclsx(
-            'font-mono text-[0.7rem] tracking-[0.08em] lowercase',
-            'text-neutral-500 dark:text-neutral-400',
-            'select-none'
-          )}
-        >
-          {displayLanguage}
-        </span>
-        <Button
-          variant='ghost'
-          size='icon-sm'
-          onClick={copyToClipboard}
-          aria-label='Copy code to clipboard'
-          className={twclsx(
-            'h-7 w-7',
-            'text-neutral-500 hover:text-neutral-900',
-            'dark:text-neutral-400 dark:hover:text-neutral-100',
-            'hover:bg-neutral-200/60 dark:hover:bg-neutral-700/40'
-          )}
-        >
-          {isCopied ? (
-            <HiCheck className='h-3.5 w-3.5 text-emerald-500' />
-          ) : (
-            <HiClipboardCopy className='h-3.5 w-3.5' />
-          )}
-        </Button>
-      </div>
-
+    <CodeBlockShell language={language}>
       <pre
-        ref={preRef}
         className={twclsx(
-          'overflow-x-auto',
+          'overflow-x-auto px-4 py-3 text-sm leading-relaxed',
           // Override prism-themes.css baseline so the inner <pre> defers to
-          // the wrapper's surface, radius, and outer spacing.
-          '[margin:0!important] [border-radius:0!important]',
+          // the shell's surface and outer spacing.
+          '[margin:0!important] [border-radius:0!important] [padding:0.75rem_1rem!important]',
           '[&>code]:border-none [&>code]:[background:transparent!important]',
           className
         )}
       >
         {children}
       </pre>
-    </div>
+    </CodeBlockShell>
   )
 }

--- a/src/components/content/mdx/Pre.tsx
+++ b/src/components/content/mdx/Pre.tsx
@@ -79,14 +79,24 @@ function MermaidCodeBlock({ children }: { children: React.ReactNode }) {
   )
 }
 
-// Helper to detect language from children
+// rehype-prism-plus emits something like `language-modelfile code-highlight`.
+// Naive `.replace('language-', '')` leaks the second class into the label
+// (yielding "MODELFILE CODE-HIGHLIGHT"); match the `language-*` token instead.
+function extractLanguage(...candidates: (string | undefined | null)[]): string {
+  for (const cn of candidates) {
+    if (!cn) continue
+    const match = cn.match(/(?:^|\s)language-([\w-]+)/)
+    if (match) return match[1]
+  }
+  return ''
+}
+
 function getLanguageFromChildren(children: React.ReactNode): string {
   try {
     const child = Children.only(children)
     if (isValidElement(child) && child.props) {
       const childProps = child.props as { className?: string }
-      const childClassName = childProps.className || ''
-      return childClassName.replace('language-', '').toLowerCase()
+      return extractLanguage(childProps.className)
     }
   } catch {
     // Multiple children or no children
@@ -98,8 +108,7 @@ export const Pre = ({ children, className }: PreProps) => {
   const [isCopied, setIsCopied] = useState<boolean>(false)
   const preRef = useRef<HTMLPreElement>(null)
 
-  // Get language from children
-  const language = getLanguageFromChildren(children)
+  const language = getLanguageFromChildren(children) || extractLanguage(className)
 
   // Hooks must always run in the same order — keep useEffect above any early
   // return (rules-of-hooks). The effect is a no-op when isCopied stays false.
@@ -121,49 +130,65 @@ export const Pre = ({ children, className }: PreProps) => {
     }
   }
 
-  const displayLanguage = className?.replace('language-', '').toUpperCase() || language?.toUpperCase() || ''
+  const displayLanguage = language || 'text'
 
   return (
-    <div className={twclsx('relative')}>
+    <div
+      className={twclsx(
+        'not-prose group relative my-6',
+        'overflow-hidden rounded-lg',
+        'border border-neutral-200 dark:border-neutral-800',
+        'bg-[var(--prism-bg)]'
+      )}
+    >
       <div
         className={twclsx(
-          'absolute right-12 left-0',
-          'h-11 rounded-tl rounded-br',
-          'text-sm font-semibold',
-          'text-main-1.5 bg-slate-700'
+          'flex items-center justify-between',
+          'border-b border-neutral-200/70 dark:border-neutral-800',
+          'bg-neutral-50/60 dark:bg-neutral-900/40',
+          'px-4 py-1.5'
         )}
       >
-        <div
+        <span
           className={twclsx(
-            'inline-flex items-center justify-start',
-            'h-full rounded-tl px-4 md:px-8',
-            'text-theme-100 bg-primary-600'
+            'font-mono text-[0.7rem] tracking-[0.08em] lowercase',
+            'text-neutral-500 dark:text-neutral-400',
+            'select-none'
           )}
         >
           {displayLanguage}
-        </div>
-      </div>
-
-      <div
-        className={twclsx(
-          'absolute top-0 right-0',
-          'flex items-center justify-center',
-          'h-11 w-11 rounded-tr rounded-bl',
-          'bg-slate-700'
-        )}
-      >
+        </span>
         <Button
           variant='ghost'
           size='icon-sm'
           onClick={copyToClipboard}
-          aria-label='Copy to clipboard'
-          className='hover:bg-slate-600'
+          aria-label='Copy code to clipboard'
+          className={twclsx(
+            'h-7 w-7',
+            'text-neutral-500 hover:text-neutral-900',
+            'dark:text-neutral-400 dark:hover:text-neutral-100',
+            'hover:bg-neutral-200/60 dark:hover:bg-neutral-700/40'
+          )}
         >
-          {isCopied ? <HiCheck className='text-emerald-500' /> : <HiClipboardCopy className='text-theme-100' />}
+          {isCopied ? (
+            <HiCheck className='h-3.5 w-3.5 text-emerald-500' />
+          ) : (
+            <HiClipboardCopy className='h-3.5 w-3.5' />
+          )}
         </Button>
       </div>
 
-      <pre ref={preRef} className={twclsx('pt-[3.5rem!important] [&>code]:border-none', className)}>
+      <pre
+        ref={preRef}
+        className={twclsx(
+          'overflow-x-auto',
+          // Override prism-themes.css baseline so the inner <pre> defers to
+          // the wrapper's surface, radius, and outer spacing.
+          '[margin:0!important] [border-radius:0!important]',
+          '[&>code]:border-none [&>code]:[background:transparent!important]',
+          className
+        )}
+      >
         {children}
       </pre>
     </div>

--- a/src/components/content/research/ResearchBibTeX.tsx
+++ b/src/components/content/research/ResearchBibTeX.tsx
@@ -1,33 +1,14 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
+import { CodeBlockShell } from '@/components/content/mdx/CodeBlockShell'
 
 import { twclsx } from '@/libs/twclsx'
-
-import { useEffect, useRef, useState } from 'react'
-import { HiCheck, HiClipboardCopy } from 'react-icons/hi'
 
 type ResearchBibTeXProps = {
   bibtex: string
 }
 
 export const ResearchBibTeX: React.FC<ResearchBibTeXProps> = ({ bibtex }) => {
-  const [isCopied, setIsCopied] = useState(false)
-  const preRef = useRef<HTMLPreElement>(null)
-
-  useEffect(() => {
-    if (!isCopied) return
-    const t = setTimeout(() => setIsCopied(false), 1500)
-    return () => clearTimeout(t)
-  }, [isCopied])
-
-  const copy = async () => {
-    if (preRef.current && !isCopied) {
-      await navigator.clipboard.writeText(preRef.current.textContent ?? '')
-      setIsCopied(true)
-    }
-  }
-
   return (
     <section id='bibtex' className={twclsx('not-prose mt-2 scroll-mt-24')}>
       <h2
@@ -35,45 +16,17 @@ export const ResearchBibTeX: React.FC<ResearchBibTeXProps> = ({ bibtex }) => {
       >
         Citation
       </h2>
-      <div className={twclsx('relative')}>
-        <div
+      <CodeBlockShell language='bibtex'>
+        <pre
           className={twclsx(
-            'absolute right-12 left-0 h-11 rounded-tl rounded-br',
-            'text-sm font-semibold',
-            'text-main-1.5 bg-slate-700'
+            'language-bibtex overflow-x-auto text-sm leading-relaxed',
+            '[margin:0!important] [border-radius:0!important] [padding:0.75rem_1rem!important]',
+            '[&>code]:border-none [&>code]:[background:transparent!important]'
           )}
         >
-          <div
-            className={twclsx(
-              'inline-flex h-full items-center justify-start rounded-tl px-4 md:px-8',
-              'text-theme-100 bg-primary-600'
-            )}
-          >
-            BIBTEX
-          </div>
-        </div>
-        <div
-          className={twclsx(
-            'absolute top-0 right-0',
-            'flex items-center justify-center',
-            'h-11 w-11 rounded-tr rounded-bl',
-            'bg-slate-700'
-          )}
-        >
-          <Button
-            variant='ghost'
-            size='icon-sm'
-            onClick={copy}
-            aria-label='Copy citation'
-            className='hover:bg-slate-600'
-          >
-            {isCopied ? <HiCheck className='text-emerald-500' /> : <HiClipboardCopy className='text-theme-100' />}
-          </Button>
-        </div>
-        <pre ref={preRef} className={twclsx('language-bibtex', '[&>code]:border-none', 'pt-[3.5rem!important]')}>
           <code className='language-bibtex'>{bibtex.trim()}</code>
         </pre>
-      </div>
+      </CodeBlockShell>
     </section>
   )
 }

--- a/src/components/content/research/ResearchBibTeX.tsx
+++ b/src/components/content/research/ResearchBibTeX.tsx
@@ -11,11 +11,6 @@ type ResearchBibTeXProps = {
 export const ResearchBibTeX: React.FC<ResearchBibTeXProps> = ({ bibtex }) => {
   return (
     <section id='bibtex' className={twclsx('not-prose mt-2 scroll-mt-24')}>
-      <h2
-        className={twclsx('text-xs font-bold tracking-wider uppercase', 'text-purple-600 dark:text-purple-400', 'mb-3')}
-      >
-        Citation
-      </h2>
       <CodeBlockShell language='bibtex'>
         <pre
           className={twclsx(

--- a/src/libs/mdxConfig.ts
+++ b/src/libs/mdxConfig.ts
@@ -1,8 +1,17 @@
 import rehypeKatex from 'rehype-katex'
 import rehypePrismPlus from 'rehype-prism-plus'
 import rehypeSlug from 'rehype-slug'
+// `rehype-prism-plus` (default) wraps `refractor/lib/all.js`. Importing the
+// same entry path gives us the exact singleton it highlights against — so
+// registering our custom Modelfile grammar here makes it available to every
+// ```modelfile fenced block without forking the plugin chain.
+import { refractor } from 'refractor/lib/all.js'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
+
+import modelfile from './prism/modelfile'
+
+refractor.register(modelfile as unknown as Parameters<typeof refractor.register>[0])
 
 export const commonMDXOptions = {
   mdxOptions: {

--- a/src/libs/prism/modelfile.ts
+++ b/src/libs/prism/modelfile.ts
@@ -1,0 +1,104 @@
+/**
+ * Prism / refractor grammar for Ollama Modelfile.
+ *
+ * Registered onto the same refractor singleton that rehype-prism-plus uses
+ * (see ../mdxConfig.ts) so ```modelfile fenced code blocks render with full
+ * token colors via the shared prism-themes.css palette.
+ *
+ * Spec reference: https://github.com/ollama/ollama/blob/main/docs/modelfile.md
+ *
+ * Architectural note (mirroring refractor's `docker.js`): the top-level
+ * `instruction` rule swallows the whole INSTRUCTION-line and runs nested
+ * `inside` rules over the residue. That preserves the lookbehind context
+ * (PARAMETER, MESSAGE) for value-level rules, which would otherwise see an
+ * already-tokenized residue and miss their anchors.
+ */
+
+// Mirror the shape that refractor v5 language modules expect: a default-exported
+// function plus `displayName` and `aliases` attached on the same function.
+type RefractorLanguage = ((Prism: { languages: Record<string, unknown> }) => void) & {
+  displayName: string
+  aliases: string[]
+}
+
+const INSTRUCTION_NAMES = 'FROM|PARAMETER|TEMPLATE|SYSTEM|ADAPTER|LICENSE|MESSAGE|REQUIRES|RENDERER|PARSER|DRAFT'
+
+const modelfile = function modelfile(Prism: { languages: Record<string, unknown> }): void {
+  // Sub-tokens shared by both block- and single-line instructions.
+  const valueInside = {
+    'parameter-name': {
+      pattern: /(^PARAMETER[ \t]+)[A-Za-z_]\w*/,
+      lookbehind: true,
+      alias: 'property'
+    },
+    'message-role': {
+      pattern: /(^MESSAGE[ \t]+)(?:system|user|assistant)\b/,
+      lookbehind: true,
+      alias: 'function'
+    },
+    string: {
+      pattern: /"(?:\\.|[^"\\\n])*"/,
+      greedy: true
+    },
+    boolean: {
+      pattern: /(^|\s)(?:true|false)(?=\s|$)/,
+      lookbehind: true
+    },
+    number: {
+      // Only stand-alone numeric values — preceded by whitespace, followed
+      // by whitespace / EOL. Skips digits embedded in paths like Qwen2.5-7B.
+      pattern: /(\s)-?\d+(?:\.\d+)?(?=\s|$)/,
+      lookbehind: true
+    },
+    keyword: new RegExp(`^(?:${INSTRUCTION_NAMES})\\b`)
+  }
+
+  Prism.languages.modelfile = {
+    comment: {
+      pattern: /(^|[^"\\])#.*/,
+      lookbehind: true,
+      greedy: true
+    },
+    'block-instruction': {
+      // SYSTEM / TEMPLATE bodies wrapped in triple quotes — multi-line.
+      pattern: new RegExp(`(^[ \\t]*)(?:SYSTEM|TEMPLATE)[ \\t]+"""[\\s\\S]*?"""`, 'm'),
+      lookbehind: true,
+      greedy: true,
+      alias: 'instruction',
+      inside: {
+        keyword: /^(?:SYSTEM|TEMPLATE)/,
+        'triple-string': {
+          pattern: /"""[\s\S]*?"""/,
+          alias: 'string',
+          greedy: true,
+          inside: {
+            'template-variable': {
+              // Go-template directives inside SYSTEM / TEMPLATE bodies.
+              pattern: /\{\{[\s\S]*?\}\}/,
+              alias: 'variable',
+              inside: {
+                keyword: /\b(?:if|else|end|range|with|define|template|block)\b/,
+                property: /\.[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*/,
+                string: /"(?:\\.|[^"\\])*"/,
+                punctuation: /[{}|]/
+              }
+            }
+          }
+        }
+      }
+    },
+    instruction: {
+      // Single-line instructions consume until end of line so `inside` rules
+      // can still anchor on the instruction keyword via lookbehind.
+      pattern: new RegExp(`(^[ \\t]*)(?:${INSTRUCTION_NAMES})\\b[^\\n]*`, 'm'),
+      lookbehind: true,
+      greedy: true,
+      inside: valueInside
+    }
+  }
+} as RefractorLanguage
+
+modelfile.displayName = 'modelfile'
+modelfile.aliases = []
+
+export default modelfile

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -377,19 +377,6 @@
       linear-gradient(315deg, rgba(59, 30, 246, 1) 25%, rgb(30 58 138) 25%);
   }
 
-  /* @tailwindcss/typography ships `content: "\``";` on `prose code::before` /
-   * `::after`, which renders literal backticks around every inline code span
-   * (e.g. <code>FROM</code> → <code>`FROM`</code>). The prose layer's pill
-   * styling already signals "inline code" — we don't need quote characters
-   * doing it a second time. Strip them across every `.prose` container
-   * (blog, portfolio, research). The plugin uses zero-specificity
-   * `:where(code)`, so dropping `:where` here yields higher specificity and
-   * wins regardless of cascade order. */
-  .prose code::before,
-  .prose code::after {
-    content: none;
-  }
-
   .img-center {
     display: flex;
     justify-content: center;
@@ -405,6 +392,20 @@
 
   * {
     @apply border-border outline-ring/50;
+  }
+}
+
+/* @tailwindcss/typography emits `content: "\``";` on `prose code::before` /
+ * `::after`, rendering literal backticks around every inline code span
+ * (e.g. <code>FROM</code> → <code>`FROM`</code>). The Code.tsx pill already
+ * signals "inline code"; the quote characters are redundant. The plugin
+ * registers its rules in `@layer utilities`, so the override must live in
+ * the same layer to win the cascade — dropping `:where()` then secures
+ * the specificity tiebreak. */
+@layer utilities {
+  .prose code::before,
+  .prose code::after {
+    content: none;
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -377,6 +377,19 @@
       linear-gradient(315deg, rgba(59, 30, 246, 1) 25%, rgb(30 58 138) 25%);
   }
 
+  /* @tailwindcss/typography ships `content: "\``";` on `prose code::before` /
+   * `::after`, which renders literal backticks around every inline code span
+   * (e.g. <code>FROM</code> → <code>`FROM`</code>). The prose layer's pill
+   * styling already signals "inline code" — we don't need quote characters
+   * doing it a second time. Strip them across every `.prose` container
+   * (blog, portfolio, research). The plugin uses zero-specificity
+   * `:where(code)`, so dropping `:where` here yields higher specificity and
+   * wins regardless of cascade order. */
+  .prose code::before,
+  .prose code::after {
+    content: none;
+  }
+
   .img-center {
     display: flex;
     justify-content: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5110,6 +5110,7 @@ __metadata:
     react-icons: "npm:5.5.0"
     react-image-lightbox: "npm:^5.1.4"
     reading-time: "npm:^1.5.0"
+    refractor: "npm:^4.8.0"
     rehype-katex: "npm:^7.0.1"
     rehype-prism-plus: "npm:^2.0.1"
     rehype-slug: "npm:^6.0.0"


### PR DESCRIPTION
## Summary

Three fixes to the recent Modelfile-syntax blog post, all surfaced by the rendered output (literal backticks around inline `code`, no syntax highlighting in the `modelfile` fenced block, a stickered slate/primary code-block header that didn't match the rest of the site):

- **Real Modelfile syntax highlighting.** New refractor grammar registered onto the same singleton `rehype-prism-plus` uses, so ` ```modelfile ` blocks now color FROM / PARAMETER / TEMPLATE / SYSTEM / MESSAGE keywords, parameter names, message roles, triple-quoted bodies, comments, and standalone numeric values. Patterned after refractor's `docker.js` (top-level instruction match with `inside` rules) so lookbehind anchors on PARAMETER / MESSAGE actually fire. Number rule requires whitespace boundaries, so `Qwen2.5-7B-Instruct-GGUF` stays plain.
- **No more literal backticks around inline code.** Global override of `@tailwindcss/typography`'s `prose code::before` / `::after` content. Dropping the `:where()` wrapping gives the rule higher specificity than the plugin's zero-spec selector, so cascade order no longer matters.
- **Code-block chrome that fits the site.** `Pre.tsx` is now a single rounded surface tinted to `var(--prism-bg)`, a thin neutral border, a quiet monospace language chip, and a ghost copy button — consistent with the site's neutral card aesthetic in both light and dark modes. Also fixed the `displayLanguage` extraction so `"MODELFILE CODE-HIGHLIGHT"` no longer leaks the rehype-prism-plus auxiliary class into the label.

`refractor` is now pinned to `^4.8.0` to match what `rehype-prism-plus@2.0.1` resolves, so yarn dedupes to a single instance — without that, the grammar lands on a copy the plugin never reads.

## Test plan

- [x] `yarn type-check` — clean
- [x] `yarn lint` — clean
- [x] `yarn test` — 60 / 60 pass
- [x] `yarn build` — green; verified rendered HTML of `/blog/modelfile-syntax-extension` contains `<span class="token keyword">FROM` / `PARAMETER` / `SYSTEM`, `<span class="token parameter-name property">temperature` / `num_ctx`, `<span class="token number">0.4`, and no stray digits inside the FROM path
- [x] Confirmed compiled CSS emits `.prose code:before,.prose code:after{content:none}` with higher specificity than the typography plugin's `:where(code)` rule
- [ ] Eyeball the page in dev / preview: language chip reads `modelfile` (lowercase), no MODELFILE CODE-HIGHLIGHT artifact, inline `code` in lists has no backticks, code-block header is subtle on both light and dark