### PR TITLE
fix(seo): serve sitemap.xml with correct Content-Type header

### DIFF
--- a/custom-next-sitemap.js
+++ b/custom-next-sitemap.js
@@ -132,11 +132,11 @@ module.exports = {
       { userAgent: 'cohere-ai', allow: '/' },
       { userAgent: 'meta-externalagent', allow: '/' }
     ],
-    additionalSitemaps: [`${siteUrl}/sitemap.xml`, `${siteUrl}/server-sitemap.xml`],
+    additionalSitemaps: [`${siteUrl}/sitemap.xml`],
     crawlDelay: 1
   },
   priority: 1.0,
-  exclude: ['/server-sitemap.xml', '/api/*', '/_next/*', '/static/*', '/.well-known/*'],
+  exclude: ['/api/*', '/_next/*', '/static/*', '/.well-known/*'],
   generateIndexSitemap: false,
   sitemapSize: 10000,
   changefreq: 'weekly',

--- a/next.config.js
+++ b/next.config.js
@@ -195,6 +195,19 @@ const config = {
             value: 'public, max-age=31536000, immutable'
           }
         ]
+      },
+      {
+        source: '/sitemap.xml',
+        headers: [
+          {
+            key: 'Content-Type',
+            value: 'application/xml; charset=utf-8'
+          },
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=86400'
+          }
+        ]
       }
     ]
   },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -66,4 +66,3 @@ Host: https://www.ahnafnafee.dev
 
 # Sitemaps
 Sitemap: https://www.ahnafnafee.dev/sitemap.xml
-Sitemap: https://www.ahnafnafee.dev/server-sitemap.xml


### PR DESCRIPTION
## Summary
- Adds `Content-Type: application/xml; charset=utf-8` header for `/sitemap.xml` in `next.config.js` — search engines were rejecting the sitemap because it was served as `text/plain`
- Removes stale `server-sitemap.xml` reference from robots.txt config — pointed to a nonexistent file/route, causing 404s for crawlers following the Sitemap directive

## Test plan
- [x] `npx next-sitemap --config=custom-next-sitemap.js` regenerates `sitemap.xml` with correct `www.ahnafnafee.dev` URLs and `robots.txt` without `server-sitemap.xml`
- [x] Dev server returns `Content-Type: application/xml; charset=utf-8` for `/sitemap.xml`
- [ ] After deploy, verify at `https://www.ahnafnafee.dev/sitemap.xml` — response header should be `application/xml`
- [ ] Resubmit sitemap to Google Search Console