### PR TITLE
fix(seo): escape ampersands in sitemap image URLs

### DIFF
--- a/custom-next-sitemap.js
+++ b/custom-next-sitemap.js
@@ -159,10 +159,14 @@ module.exports = {
           ? { url: staticImage.image, title: staticImage.title }
           : null
     if (imageMeta) {
-      // next-sitemap reads `image.loc.href`, so wrap in a URL object.
-      // Skip silently if the URL is malformed (don't block the build).
+      // next-sitemap reads `image.loc.href` and writes it into <image:loc>
+      // WITHOUT XML-escaping. Wrap in a URL object to validate, then expose
+      // a pre-escaped href so `&` in query strings becomes `&amp;`.
       try {
-        entry.images = [{ loc: new URL(imageMeta.url), title: imageMeta.title }]
+        const validated = new URL(imageMeta.url)
+        entry.images = [
+          { loc: { href: validated.href.replace(/&/g, '&amp;') }, title: imageMeta.title }
+        ]
       } catch (err) {
         console.warn(`[sitemap] image URL invalid for ${urlPath}:`, err.message)
       }


### PR DESCRIPTION
## Summary
- `next-sitemap` writes `image.loc.href` into `<image:loc>` without XML-escaping, so URLs with `&` in query strings (e.g. `?ik-sdk-version=1.4.3&updatedAt=...`) produced invalid XML
- Fix: pre-escape `&` → `&amp;` before passing the URL to `next-sitemap`

## Test plan
- [x] Regenerated sitemap locally — 14 `&amp;` entries, zero unescaped `&`
- [x] Python XML parser confirms well-formed XML
- [ ] After deploy, verify `https://www.ahnafnafee.dev/sitemap.xml` renders without XML errors
- [ ] Resubmit sitemap in Google Search Console