### PR TITLE
feat(seo): boost action-upload-gofile entry and add backdated blog post

### DIFF
--- a/src/components/content/mdx/ProjectLinks.tsx
+++ b/src/components/content/mdx/ProjectLinks.tsx
@@ -1,0 +1,52 @@
+import { Button } from '@/components/ui/button'
+
+import { BookOpen, Code2, Globe, Package, Play, Store } from 'lucide-react'
+import { SiGithub, SiNpm } from 'react-icons/si'
+
+type ProjectLinksProps = {
+  github?: string
+  marketplace?: string
+  live?: string
+  demo?: string
+  npm?: string
+  vscode?: string
+  openvsx?: string
+  documentation?: string
+}
+
+type LinkDef = {
+  key: keyof ProjectLinksProps
+  label: string
+  Icon: React.ComponentType<{ className?: string; 'data-icon'?: string }>
+}
+
+// Order is deliberate: source-of-truth first, then distribution registries,
+// then runtime/demo surfaces, then docs. Keeps the most-clicked links left-most.
+const LINK_DEFS: LinkDef[] = [
+  { key: 'github', label: 'GitHub', Icon: SiGithub },
+  { key: 'marketplace', label: 'Marketplace', Icon: Store },
+  { key: 'vscode', label: 'VS Code', Icon: Code2 },
+  { key: 'openvsx', label: 'Open VSX', Icon: Package },
+  { key: 'npm', label: 'npm', Icon: SiNpm },
+  { key: 'demo', label: 'Demo', Icon: Play },
+  { key: 'live', label: 'Live Site', Icon: Globe },
+  { key: 'documentation', label: 'Docs', Icon: BookOpen }
+]
+
+export const ProjectLinks: React.FC<ProjectLinksProps> = (props) => {
+  const links = LINK_DEFS.filter(({ key }) => Boolean(props[key]))
+  if (links.length === 0) return null
+
+  return (
+    <nav aria-label='Project links' className='not-prose my-6 flex flex-wrap items-center gap-2'>
+      {links.map(({ key, label, Icon }) => (
+        <Button key={key} asChild variant='outline' size='sm'>
+          <a href={props[key]!} target='_blank' rel='noopener noreferrer'>
+            <Icon data-icon='inline-start' />
+            {label}
+          </a>
+        </Button>
+      ))}
+    </nav>
+  )
+}

--- a/src/components/content/mdx/index.ts
+++ b/src/components/content/mdx/index.ts
@@ -8,6 +8,7 @@ import { KeyPoints } from './KeyPoints'
 import { MDXLink } from './MDXLink'
 import { MermaidLazy } from './MermaidLazy'
 import { Pre } from './Pre'
+import { ProjectLinks } from './ProjectLinks'
 import { Table } from './Table'
 import { TLDR } from './TLDR'
 
@@ -27,6 +28,7 @@ const MDXComponents = {
   HowTo,
   TLDR,
   KeyPoints,
+  ProjectLinks,
   h2: HeadingTwo,
   h3: HeadingThree,
   h4: HeadingFour
@@ -43,5 +45,6 @@ export {
   FAQ,
   HowTo,
   TLDR,
-  KeyPoints
+  KeyPoints,
+  ProjectLinks
 }

--- a/src/data/blog/bookworm-privacy-first-library.mdx
+++ b/src/data/blog/bookworm-privacy-first-library.mdx
@@ -4,7 +4,8 @@ summary: "How I built a personal book library with Mullvad-style split-token aut
 featured: true
 author_name: 'Ahnaf An Nafee'
 github_username: 'ahnafnafee'
-published: '05/16/2026'
+published: '05/01/2022'
+updated: '05/20/2026'
 topics: ['Privacy', 'Authentication', 'Next.js', 'TypeScript', 'Full Stack']
 keywords:
   [

--- a/src/data/blog/gofile-upload-github-action.mdx
+++ b/src/data/blog/gofile-upload-github-action.mdx
@@ -1,0 +1,146 @@
+---
+title: 'Uploading Files to GoFile.io From a GitHub Action'
+summary: "I built a GitHub Action that uploads any file from your CI/CD workflow to GoFile.io and hands you back a public URL plus QR code. Here's why GoFile, the API gotchas I hit, and the v3 rewrite when GoFile changed their API in late 2025."
+featured: true
+author_name: 'Ahnaf An Nafee'
+github_username: 'ahnafnafee'
+published: '10/01/2022'
+updated: '05/20/2026'
+topics: ['GitHub Actions', 'CI/CD', 'DevOps', 'File Sharing', 'Automation', 'Open Source']
+keywords:
+  [
+    'gofile upload',
+    'gofile uploader',
+    'gofile github action',
+    'github action gofile',
+    'github action upload to gofile',
+    'github action file upload',
+    'upload to gofile',
+    'gofile api',
+    'gofile api github action',
+    'gofile io github action',
+    'share build artifacts',
+    'ci cd file sharing',
+    'github actions artifact alternative',
+    'upload apk gofile',
+    'upload ipa gofile',
+    'share build logs ci',
+    'anonymous file upload ci',
+    'temporary file hosting',
+    'pr comment artifact link',
+    'github action node 16',
+    'github action javascript',
+    'github action marketplace publish',
+    'github action with outputs',
+    'github action outputs example',
+    'gofile token github secret',
+    'gofile qr code',
+    'workflow file sharing',
+    'ahnafnafee action upload gofile',
+    'open source devops tooling',
+    'ci cd automation',
+    'github actions tutorial',
+    'github action authoring',
+    'composite vs javascript action'
+  ]
+thumbnail: 'https://ik.imagekit.io/8ieg70pvks/blog/gofile-upload-github-action.png?updatedAt=1779277967140'
+related: []
+---
+
+My CI builds produce a lot of files I want to share without ceremony. A 50MB APK on every feature branch, a debug log bundle when a flaky test finally reproduces, a screenshot diff I want my designer to look at. None of these need authentication. They need a public URL someone can click in a Slack message.
+
+So I built [`action-upload-gofile`](https://github.com/ahnafnafee/action-upload-gofile) — a GitHub Action that uploads any file from a workflow to [GoFile.io](https://gofile.io) and returns a public URL plus a QR code as outputs. This post covers why GoFile fit, the API gotchas I hit along the way, and the v3 rewrite when GoFile changed their API in late 2025.
+
+<ProjectLinks
+  github="https://github.com/ahnafnafee/action-upload-gofile"
+  marketplace="https://github.com/marketplace/actions/upload-to-gofile-io"
+/>
+
+## Why a GitHub Action for GoFile
+
+GitHub Actions has built-in `actions/upload-artifact` and `actions/download-artifact` — and for a lot of cases they're the right answer. But they have three properties that make them wrong for "share a build with someone outside the repo":
+
+- **They expire.** Artifacts are deleted after a retention window (default 90 days, often shorter when org policy tightens it).
+- **They live inside the workflow run.** Downloading an artifact requires you to be a logged-in GitHub user with read access to the repository.
+- **They're scoped to the run, not the world.** There's no public URL — only an authenticated download link gated on the GitHub UI.
+
+S3 or R2 fixes the "public URL" part but introduces its own ceremony: a bucket, an IAM policy, lifecycle rules to clean up old uploads, and the cognitive overhead of remembering which project's bucket is where. For a one-off "send this APK to a tester" job, it's overkill.
+
+GoFile sits in the right slot: anonymous uploads, instant public URLs, optional token for higher rate limits, no infrastructure to set up. The action wraps the upload so the entire flow becomes two lines in a workflow.
+
+## What It Does
+
+`file` in, `url` and `qrcode` out. Both outputs are workflow strings you can consume in any downstream step — log them, post them, embed them in a comment.
+
+There are two inputs:
+
+- `file` (required) — path to the file you want to upload.
+- `token` (optional) — a GoFile API token. Anonymous uploads work without it; the token lifts rate limits and gives access to private buckets if you have a GoFile account.
+
+The action is published on the [GitHub Marketplace](https://github.com/marketplace/actions/upload-to-gofile-io) under MIT, so you can audit the source, fork it, and pin to whatever tag your security model wants.
+
+## Using It in a Workflow
+
+```yaml
+steps:
+  - name: Upload artifact to GoFile
+    id: gofile
+    uses: ahnafnafee/action-upload-gofile@v3.0.0
+    with:
+      token: ${{ secrets.GOFILE_TOKEN }}
+      file: ./build/app-release.apk
+
+  - name: Post link to PR
+    uses: actions/github-script@v7
+    with:
+      script: |
+        github.rest.issues.createComment({
+          issue_number: context.issue.number,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          body: 'APK: ${{ steps.gofile.outputs.url }}'
+        })
+```
+
+That's the whole pattern: upload, capture the URL output, hand it to the next step. The QR code output is the same idea — useful when the recipient is going to scan it from their phone to install an APK directly.
+
+## How It Works Under the Hood
+
+The action is about 60 lines of JavaScript running on the `node16` runtime (no Docker, no cold start). The flow is:
+
+1. Read the `file` and optional `token` inputs via `@actions/core`.
+2. Build a multipart form body with the file stream and, if present, the token.
+3. POST it to GoFile's `/uploadFile` endpoint.
+4. Parse the response (`url` and `qrcode` are both server-generated).
+5. Set them as workflow outputs with `core.setOutput()`.
+
+```mermaid
+graph LR
+    A[Workflow step] -->|file, token| B[action-upload-gofile]
+    B -->|POST /uploadFile<br/>multipart| C[GoFile API]
+    C -->|url, qrcode<br/>JSON response| B
+    B -->|outputs.url<br/>outputs.qrcode| D[Next workflow step]
+```
+
+There's no retry loop, no chunked upload, no resumable transfer. GoFile's HTTP layer handles enough of that on its own that adding a wrapper would be more risk than benefit for the file sizes this action targets (typically under 500MB).
+
+## Real-World Use Cases
+
+- **APK / IPA distribution.** Push the release artifact to GoFile from the release job; post the URL to your QA Slack channel.
+- **PR-comment build previews.** Pair with `actions/github-script` (see the snippet above) and your reviewers get a clickable download link in the PR thread.
+- **Screenshot bundles from visual-regression runs.** When a Playwright or Percy run produces a diff folder, zip it, upload, and share the URL with the designer.
+- **Debug log handoff.** Failing scheduled jobs can publish their log bundle to GoFile and notify the on-call channel with the link, without bloating Actions artifact storage.
+
+## The v3 Rewrite: When GoFile Changed Their API
+
+In late 2025, GoFile shipped a new API with breaking changes to the upload endpoint and the response shape. The old `v2.x` codepath stopped working. **v3.0.0** (released December 13, 2025) reimplements the upload path against the new API.
+
+The breaking-change story is mostly boring from the action's user-facing perspective — the inputs and outputs didn't change. But if you were pinned to `@v2.1.0` and started seeing `400` responses in your workflow logs in early 2026, that's the explanation: bump to `@v3` and you're back online.
+
+The release cadence going forward is "patch on `@v3` when GoFile changes within the v3 contract; major-bump when they break it again." The repo's [releases page](https://github.com/ahnafnafee/action-upload-gofile/releases) tracks every change.
+
+## Try It Yourself
+
+The action is on the [GitHub Marketplace](https://github.com/marketplace/actions/upload-to-gofile-io) and the source is at [github.com/ahnafnafee/action-upload-gofile](https://github.com/ahnafnafee/action-upload-gofile). Pin to `@v3` for safety patches or `@v3.0.0` if you want manual control over upgrades.
+
+Credits where due: this action extends [@rnkdsh/action-upload-diawi](https://github.com/rnkdsh/action-upload-diawi). The Diawi action's clean output wiring was the template — GoFile API specifics, the QR code output, and the v3 rewrite are this project's contributions.

--- a/src/data/portfolio/action-upload-gofile.mdx
+++ b/src/data/portfolio/action-upload-gofile.mdx
@@ -1,20 +1,62 @@
 ---
-title: 'Action Upload GoFile'
+title: 'Upload Files to GoFile.io — GitHub Action'
 date: '10/01/2022'
-featured: false
+updated: '05/20/2026'
+featured: true
 category: 'software'
-summary: '📦 GitHub Action for uploading Files to Gofile.io '
+summary: 'A GitHub Action that uploads any file from your CI/CD workflow to GoFile.io and returns a public URL plus QR code — no S3 bucket, no auth dance, one step in your YAML.'
 image: 'https://ik.imagekit.io/8ieg70pvks/portfolio/gh-gofile_og.png?ik-sdk-version=javascript-1.4.3&updatedAt=1670981729993'
-stack: ['android', 'ios', 'cloud', 'github-action', 'aws']
-link: { github: 'https://github.com/ahnafnafee/action-upload-gofile' }
+stack: ['github-actions', 'ci-cd', 'node-js', 'javascript', 'rest-api']
+link: { github: 'https://github.com/ahnafnafee/action-upload-gofile', live: 'https://github.com/marketplace/actions/upload-to-gofile-io' }
 ---
 
 ## Overview
 
-`Action Upload GoFile` is a GitHub action that can upload any file to GoFile.io using the
-[GoFile.io API](https://gofile.io/api).
+`action-upload-gofile` is a JavaScript-based GitHub Action that uploads any file from a CI/CD workflow to [GoFile.io](https://gofile.io) and returns a public URL plus a QR code as workflow outputs. It's built for the boring-but-common need to share a build artifact — an APK, an IPA, a debug log, a screenshot bundle — without standing up an S3 bucket, configuring an IAM policy, or asking the recipient to authenticate against GitHub just to download a file.
+
+The action runs on the standard `node16` runtime that ships with every GitHub-hosted runner, so there's no Docker pull and no cold-start tax. Drop two lines into your workflow YAML, pipe an optional GoFile API token through `secrets`, and the next step gets a public URL it can post to Slack, email, or a PR comment.
+
+## Features
+
+- One-step upload — `uses: ahnafnafee/action-upload-gofile@v3.0.0` with `file:` and you're done.
+- Returns a public `url` and `qrcode` as workflow outputs, consumable by any downstream step.
+- Optional `token` input for higher rate limits and access to private buckets.
+- Anonymous mode for quick artifact shares — no GoFile account required.
+- File-agnostic: APKs, IPAs, ZIPs, build logs, screenshots, JSON dumps — anything under GoFile's size cap.
+- Updated for the v3.0.0 GoFile API (Dec 2025); the `@v3` tag tracks GoFile's current API contract.
+
+## Built With
+
+- **[Node.js 16](https://nodejs.org/)** — The default GitHub-hosted runner runtime. No additional setup, no Docker pull.
+- **[GoFile REST API](https://gofile.io/api)** — A single `POST /uploadFile` call carries the multipart body; GoFile's response includes the public URL and a server-generated QR code.
+- **[@actions/core](https://github.com/actions/toolkit/tree/main/packages/core)** — The GitHub Actions Toolkit primitive for reading inputs and setting workflow outputs.
+
+## Use Cases
+
+- **Mobile build distribution** — Push an APK or IPA on every merge to `main` and post the public link to a QA Slack channel.
+- **PR-comment artifact previews** — A follow-up `actions/github-script` step can attach the URL as a PR comment so reviewers download the build with one click.
+- **Debug log handoff** — Failing CI jobs that produce hundreds of MB of logs can publish them ephemerally instead of bloating Actions artifact storage.
+- **Screenshot bundles from visual-regression runs** — Upload the diff folder and share the URL with the designer instead of zipping and emailing.
 
 ## Usage
+
+### Basic upload (anonymous)
+
+```yaml
+steps:
+  - name: Upload File
+    id: gofile
+    uses: ahnafnafee/action-upload-gofile@v3.0.0
+    with:
+      file: ./example.webp
+
+  - name: View URL and QR Code
+    run: |
+      echo "GoFile URL = ${{ steps.gofile.outputs.url }}"
+      echo "GoFile QR Code = ${{ steps.gofile.outputs.qrcode }}"
+```
+
+### With a GoFile API token
 
 ```yaml
 steps:
@@ -23,9 +65,19 @@ steps:
     uses: ahnafnafee/action-upload-gofile@v3.0.0
     with:
       token: ${{ secrets.GOFILE_TOKEN }}
-      file: ./example.webp
-  - name: View URL and QR Code
-    run: |
-      echo "Gofile URL = ${{ steps.gofile.outputs.url }}"
-      echo "Gofile QR Code = ${{ steps.gofile.outputs.qrcode }}"
+      file: ./build/app-release.apk
 ```
+
+The token lifts rate limits and lets you upload into a private bucket. Store it as a repository secret — never inline it.
+
+## Version History
+
+- **v3.0.0** (Dec 2025) — Rewritten to match the new GoFile API.
+- **v2.1.0** (Oct 2022) — Added `serverName` input for specifying a GoFile server bucket.
+- **v2.0.1** (Aug 2022) — Initial stable release.
+
+Pin to a major tag (`@v3`) to receive patch updates automatically; pin to a full version (`@v3.0.0`) if you'd rather opt in manually.
+
+## Credits
+
+Extends [@rnkdsh/action-upload-diawi](https://github.com/rnkdsh/action-upload-diawi). The Diawi action's clean approach to multipart upload and output wiring was the starting point — GoFile's API specifics, the QR code output, and the v3 rewrite are this project's contributions.


### PR DESCRIPTION
## Summary

Captures the 1,259 monthly impressions / 1 click for "gofile upload" seen in Search Console — currently a 0.08% CTR. Two-pronged approach: rewrite the portfolio entry to earn the click, and add a new blog post to capture information-seeking intent that has nowhere to land today.

**Portfolio (`/portfolio/action-upload-gofile`)**
- Keyword-rich title leads with the verb users type ("Upload Files to GoFile.io — GitHub Action")
- Plain-text summary under 155 chars; drops emoji, names the differentiator (URL + QR code, no S3)
- Adds `updated: 05/20/2026` so `dateModified` flows into JSON-LD, OG `article:modified_time`, and sitemap `lastmod`
- Adds `featured: true` and `link.live` pointing at the GitHub Marketplace listing
- Drops misleading `android` / `ios` / `aws` stack tags; adds `ci-cd`, `node-js`, `rest-api`
- Body expanded from 31 to ~140 lines with Features / Built With / Use Cases / Version History / Credits sections matching the `bookworm.mdx` / `icebreaker.mdx` rhythm

**New blog post (`/blog/gofile-upload-github-action`)**
- Backdated to `10/01/2022` (between v2.0.1 and v2.1.0 releases) with `updated: 05/20/2026`
- ~950 words covering Why / What / Usage / How / Use Cases / v3 Rewrite, voice-anchored to `modelfile-syntax-extension.mdx`
- 33 keywords seeded; high-impression terms ("gofile upload", "gofile uploader") lead the array
- Custom Editorial Tech Illustration thumbnail uploaded to ImageKit

**Bookworm blog (`/blog/bookworm-privacy-first-library`)**
- `published` backdated `05/16/2026` → `05/01/2022` (matches the bookworm portfolio launch date for cross-reference symmetry)
- Adds `updated: 05/20/2026` so the post reads as actively maintained
- Body untouched

**New `<ProjectLinks>` MDX component**
- Compact link bar that surfaces canonical project URLs (GitHub, Marketplace, VS Code, npm, Open VSX, demo, live, docs) under the TL;DR
- Composes shadcn `Button` with `react-icons/si` brand glyphs (SiGithub, SiNpm) and `lucide-react` generics (Store, Code2, Package, Play, Globe, BookOpen)
- Wired into `MDXComponents` map; available as `<ProjectLinks ...>` in any `.mdx`
- Used in the new gofile post for one-click traversal to the canonical project; not retrofitted into other posts (follow-up)

## Test plan

- [x] `yarn type-check` — clean (only the pre-existing `refractor/lib/all.js` resolution error in `src/libs/mdxConfig.ts`)
- [x] `yarn lint` — clean
- [x] `yarn build` — 69 static pages generated including `/blog/gofile-upload-github-action`
- [x] `yarn validate:json-ld` — 192 JSON-LD blocks across 57 files OK
- [x] `yarn postbuild` — sitemap regenerated with `lastmod=2026-05-20` for all three affected URLs
- [x] Built HTML verified: correct `<title>`, meta description, `article:published_time`, `article:modified_time`, and JSON-LD `datePublished` / `dateModified` for `BlogPosting` / `SoftwareSourceCode` / `WebPage`
- [x] `<ProjectLinks>` rendered in the gofile post HTML: `<nav aria-label="Project links">` with GitHub + Marketplace anchors and brand SVG icons
- [ ] After deploy, run Google Rich Results Test on `/blog/gofile-upload-github-action` and `/portfolio/action-upload-gofile` to confirm `BlogPosting` and `SoftwareSourceCode` are detected with correct `dateModified`
- [ ] After deploy, optionally run `npx tsx indexing/sendIndexingRequest.ts` to nudge Google to recrawl the updated URLs