### PR TITLE
fix(seo): adsense readiness, consent mode, and search console cleanup

### DIFF
--- a/custom-next-sitemap.js
+++ b/custom-next-sitemap.js
@@ -94,12 +94,14 @@ const STATIC_PAGE_IMAGES = {
 function priorityFor(path) {
   if (path === '/') return { priority: 1.0, changefreq: 'weekly' }
   if (path === '/resume') return { priority: 0.9, changefreq: 'monthly' }
+  // Utility / legal pages — crawlable and linked, but ranked below content.
+  if (path === '/about' || path === '/contact' || path === '/privacy-policy' || path === '/security-policy')
+    return { priority: 0.4, changefreq: 'yearly' }
   if (path === '/portfolio' || path === '/blog') return { priority: 0.8, changefreq: 'weekly' }
   if (path === '/research') return { priority: 0.8, changefreq: 'weekly' }
   if (path.startsWith('/portfolio/')) return { priority: 0.7, changefreq: 'monthly' }
   if (path.startsWith('/research/')) return { priority: 0.75, changefreq: 'monthly' }
   if (path.startsWith('/blog/')) return { priority: 0.6, changefreq: 'monthly' }
-  if (path.startsWith('/snippet/')) return { priority: 0.5, changefreq: 'monthly' }
   return { priority: 0.7, changefreq: 'monthly' }
 }
 
@@ -136,7 +138,10 @@ module.exports = {
     crawlDelay: 1
   },
   priority: 1.0,
-  exclude: ['/api/*', '/_next/*', '/static/*', '/.well-known/*'],
+  // /offline and topic leaf pages are noindexed (PWA fallback / thin tag
+  // listings) — keep the sitemap consistent with the robots meta. The
+  // /blog/topics hub itself stays included.
+  exclude: ['/api/*', '/_next/*', '/static/*', '/.well-known/*', '/offline', '/blog/topics/*'],
   generateIndexSitemap: false,
   sitemapSize: 10000,
   changefreq: 'weekly',
@@ -164,9 +169,7 @@ module.exports = {
       // a pre-escaped href so `&` in query strings becomes `&amp;`.
       try {
         const validated = new URL(imageMeta.url)
-        entry.images = [
-          { loc: { href: validated.href.replace(/&/g, '&amp;') }, title: imageMeta.title }
-        ]
+        entry.images = [{ loc: { href: validated.href.replace(/&/g, '&amp;') }, title: imageMeta.title }]
       } catch (err) {
         console.warn(`[sitemap] image URL invalid for ${urlPath}:`, err.message)
       }

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const isDev = process.env.NODE_ENV === 'development'
 // https://nextjs.org/docs/advanced-features/security-headers
 const ContentSecurityPolicy = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' *.youtube.com *.twitter.com *.vercel-scripts.com giscus.app *.giscus.app *.googletagmanager.com cdn.jsdelivr.net pagead2.googlesyndication.com *.googlesyndication.com *.google.com *.googleadservices.com adservice.google.com;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' *.youtube.com *.twitter.com *.vercel-scripts.com giscus.app *.giscus.app *.googletagmanager.com cdn.jsdelivr.net pagead2.googlesyndication.com *.googlesyndication.com *.google.com *.googleadservices.com adservice.google.com *.gstatic.com *.doubleclick.net;
     child-src *.youtube.com *.google.com *.twitter.com giscus.app *.giscus.app;
     style-src 'self' 'unsafe-inline' *.googleapis.com *.unpkg.com *.giscus.app;
     img-src * blob: data:;
@@ -259,6 +259,17 @@ const config = {
       {
         source: '/tags',
         destination: '/blog/topics',
+        permanent: true
+      },
+      // Retired snippets section — closest surviving content lives on the blog.
+      {
+        source: '/snippet',
+        destination: '/blog',
+        permanent: true
+      },
+      {
+        source: '/snippet/:path*',
+        destination: '/blog',
         permanent: true
       },
       {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,122 @@
+import { generateOgImage } from '@/libs/metapage'
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+const ABOUT_OG_IMAGE = generateOgImage({
+  title: 'About',
+  subTitle: 'Ahnaf An Nafee — PhD Student in AI & 3D Graphics',
+  type: 'page'
+})
+
+export const metadata: Metadata = {
+  title: 'About - Ahnaf An Nafee',
+  description:
+    'About Ahnaf An Nafee — PhD student in AI and 3D computer graphics at George Mason University, former startup CTO, and the person behind ahnafnafee.dev.',
+  keywords: ['about ahnaf an nafee', 'ai researcher', '3d graphics', 'gmu phd', 'dcxr lab'],
+  alternates: {
+    canonical: 'https://www.ahnafnafee.dev/about'
+  },
+  openGraph: {
+    title: 'About - Ahnaf An Nafee',
+    description: 'PhD student in AI and 3D computer graphics, former startup CTO, and the person behind this site.',
+    url: 'https://www.ahnafnafee.dev/about',
+    siteName: 'Ahnaf An Nafee',
+    images: [
+      {
+        url: ABOUT_OG_IMAGE,
+        width: 1200,
+        height: 600,
+        alt: 'About - Ahnaf An Nafee'
+      }
+    ],
+    locale: 'en_US',
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About - Ahnaf An Nafee',
+    description: 'PhD student in AI and 3D computer graphics, former startup CTO, and the person behind this site.',
+    site: '@ahnaf_nafee',
+    creator: '@ahnaf_nafee',
+    images: [ABOUT_OG_IMAGE]
+  }
+}
+
+export default function AboutPage() {
+  return (
+    <main className='layout'>
+      <div className='mx-auto max-w-4xl py-8'>
+        <h1 className='mb-8 text-3xl font-bold tracking-tight text-black md:text-4xl dark:text-white'>About</h1>
+
+        <div className='prose prose-gray dark:prose-invert max-w-none'>
+          <section className='mb-8'>
+            <p className='mb-4'>
+              I&rsquo;m Ahnaf An Nafee, a PhD student working at the intersection of{' '}
+              <strong>artificial intelligence and 3D computer graphics</strong> in the DCXR Lab at George Mason
+              University, advised by Dr. Craig Yu. My research looks at how machine learning can change the way we
+              create and inhabit immersive digital worlds — from AI-driven 3D content generation to rendering pipelines
+              and immersive XR.
+            </p>
+            <p className='mb-4'>
+              Before graduate school I led engineering as the CTO of a technology startup, where I shipped production
+              software across the full stack and managed a small team. That mix of research and real-world engineering
+              shapes how I write and build: I care about ideas that actually run.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>What This Site Is</h2>
+            <p className='mb-4'>This site is my portfolio and personal blog. It brings together three things:</p>
+            <ul className='mb-4 list-disc pl-6'>
+              <li>
+                <Link href='/blog' className='text-primary-600 hover:text-primary-700'>
+                  The blog
+                </Link>{' '}
+                — long-form, first-person write-ups on AI, 3D graphics, and software engineering: things I&rsquo;ve
+                built, tools I&rsquo;ve shipped, and problems I&rsquo;ve worked through in detail.
+              </li>
+              <li>
+                <Link href='/portfolio' className='text-primary-600 hover:text-primary-700'>
+                  The portfolio
+                </Link>{' '}
+                — selected projects spanning games, developer tooling, mobile apps, and research prototypes.
+              </li>
+              <li>
+                <Link href='/research' className='text-primary-600 hover:text-primary-700'>
+                  Research
+                </Link>{' '}
+                — papers and projects in AI and 3D computer graphics.
+              </li>
+            </ul>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>What I Write About</h2>
+            <p className='mb-4'>
+              Most posts here start from something I actually built and needed to understand well. Recurring themes
+              include applied machine learning and local LLM workflows, 3D graphics and rendering, developer tools and
+              automation, and the engineering trade-offs behind shipping software as a small team or a solo developer.
+              Every post is original and written from firsthand experience.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Get in Touch</h2>
+            <p className='mb-4'>
+              You can read more about my background on my{' '}
+              <Link href='/resume' className='text-primary-600 hover:text-primary-700'>
+                resume
+              </Link>
+              , or reach me directly through the{' '}
+              <Link href='/contact' className='text-primary-600 hover:text-primary-700'>
+                contact page
+              </Link>
+              . I&rsquo;m always happy to talk about research, collaborations, or anything I&rsquo;ve written here.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/blog/topics/[topic]/page.tsx
+++ b/src/app/blog/topics/[topic]/page.tsx
@@ -80,6 +80,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title: `${label} — Blog Topics`,
     description,
     alternates: { canonical: url },
+    // Topic pages are thin near-duplicates of the blog index (most tag exactly
+    // one post) — noindex keeps them out of Search/AdSense quality signals
+    // while `follow` still passes link equity to the posts. Revisit when the
+    // blog is large enough that topic hubs aggregate real content.
+    robots: { index: false, follow: true },
     openGraph: {
       title: ogTitle,
       description,

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,146 @@
+import { SITE_AUTHOR } from '@/libs/constants/site'
+import { generateOgImage } from '@/libs/metapage'
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+
+const CONTACT_OG_IMAGE = generateOgImage({
+  title: 'Contact',
+  subTitle: 'Get in touch with Ahnaf An Nafee',
+  type: 'page'
+})
+
+export const metadata: Metadata = {
+  title: 'Contact - Ahnaf An Nafee',
+  description: 'Get in touch with Ahnaf An Nafee — email, LinkedIn, GitHub, and other ways to reach me.',
+  keywords: ['contact ahnaf an nafee', 'get in touch', 'email', 'linkedin', 'github'],
+  alternates: {
+    canonical: 'https://www.ahnafnafee.dev/contact'
+  },
+  openGraph: {
+    title: 'Contact - Ahnaf An Nafee',
+    description: 'Email, LinkedIn, GitHub, and other ways to reach me.',
+    url: 'https://www.ahnafnafee.dev/contact',
+    siteName: 'Ahnaf An Nafee',
+    images: [
+      {
+        url: CONTACT_OG_IMAGE,
+        width: 1200,
+        height: 600,
+        alt: 'Contact - Ahnaf An Nafee'
+      }
+    ],
+    locale: 'en_US',
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact - Ahnaf An Nafee',
+    description: 'Email, LinkedIn, GitHub, and other ways to reach me.',
+    site: '@ahnaf_nafee',
+    creator: '@ahnaf_nafee',
+    images: [CONTACT_OG_IMAGE]
+  }
+}
+
+export default function ContactPage() {
+  return (
+    <main className='layout'>
+      <div className='mx-auto max-w-4xl py-8'>
+        <h1 className='mb-8 text-3xl font-bold tracking-tight text-black md:text-4xl dark:text-white'>Contact</h1>
+
+        <div className='prose prose-gray dark:prose-invert max-w-none'>
+          <section className='mb-8'>
+            <p className='mb-4'>
+              Have a question about something I&rsquo;ve written, want to talk research or collaboration, or just want
+              to say hello? The best way to reach me is by email — I read everything, though it may take a few days to
+              reply.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Email</h2>
+            <p className='mb-4'>
+              <a href={`mailto:${SITE_AUTHOR.email}`} className='text-primary-600 hover:text-primary-700'>
+                {SITE_AUTHOR.email}
+              </a>
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Elsewhere</h2>
+            <ul className='mb-4 list-disc pl-6'>
+              <li>
+                <strong>LinkedIn:</strong>{' '}
+                <a
+                  href='https://www.linkedin.com/in/ahnafnafee'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  linkedin.com/in/ahnafnafee
+                </a>
+              </li>
+              <li>
+                <strong>GitHub:</strong>{' '}
+                <a
+                  href='https://github.com/ahnafnafee'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  github.com/ahnafnafee
+                </a>
+              </li>
+              <li>
+                <strong>X (Twitter):</strong>{' '}
+                <a
+                  href='https://twitter.com/ahnaf_nafee'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  @ahnaf_nafee
+                </a>
+              </li>
+              <li>
+                <strong>Google Scholar:</strong>{' '}
+                <a
+                  href='https://scholar.google.com/citations?user=u15DO0cAAAAJ&hl=en'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  Ahnaf An Nafee
+                </a>
+              </li>
+              <li>
+                <strong>ORCID:</strong>{' '}
+                <a
+                  href='https://orcid.org/0009-0000-9363-4536'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  0009-0000-9363-4536
+                </a>
+              </li>
+            </ul>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Reporting a Security Issue</h2>
+            <p className='mb-4'>
+              If you&rsquo;ve found a security vulnerability on this site, please follow the responsible-disclosure
+              steps on my{' '}
+              <Link href='/security-policy' className='text-primary-600 hover:text-primary-700'>
+                Security Policy
+              </Link>{' '}
+              page instead of the general contact channels above.
+            </p>
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -97,6 +97,24 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             {`
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
+
+            // Consent Mode v2 — storage defaults to denied in regions whose law
+            // requires opt-in consent (EEA + UK + CH). Google's certified CMP
+            // (AdSense Privacy & messaging, served via the adsbygoogle script)
+            // shows the consent banner in those regions and updates these
+            // signals on the visitor's choice; wait_for_update holds tags
+            // briefly so a stored choice applies before anything fires.
+            // Visitors elsewhere keep the regular defaults.
+            gtag('consent', 'default', {
+              ad_storage: 'denied',
+              ad_user_data: 'denied',
+              ad_personalization: 'denied',
+              analytics_storage: 'denied',
+              wait_for_update: 500,
+              region: ['AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IS','IE','IT','LV','LI','LT','LU','MT','NL','NO','PL','PT','RO','SK','SI','ES','SE','GB','CH']
+            });
+            gtag('set', 'ads_data_redaction', true);
+
             gtag('js', new Date());
 
             gtag('config', 'G-7S76865HNX');

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'You Are Offline',
-  description: `It looks like you are offline, please connect to your internet connection and try refreshing this page.`
+  description: `It looks like you are offline, please connect to your internet connection and try refreshing this page.`,
+  // PWA fallback page — never useful in search results.
+  robots: { index: false, follow: false }
 }
 
 export default function OfflinePage() {

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,0 +1,259 @@
+import { SITE_AUTHOR } from '@/libs/constants/site'
+import { generateOgImage } from '@/libs/metapage'
+
+import type { Metadata } from 'next'
+
+const PRIVACY_OG_IMAGE = generateOgImage({
+  title: 'Privacy Policy',
+  subTitle: 'How this site handles data, cookies, and ads',
+  type: 'page'
+})
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - Ahnaf An Nafee',
+  description:
+    'Privacy policy for ahnafnafee.dev — how cookies, analytics, and third-party advertising (Google AdSense) are used on this site.',
+  keywords: ['privacy policy', 'cookies', 'google adsense', 'analytics', 'ahnafnafee privacy'],
+  alternates: {
+    canonical: 'https://www.ahnafnafee.dev/privacy-policy'
+  },
+  openGraph: {
+    title: 'Privacy Policy - Ahnaf An Nafee',
+    description: 'How cookies, analytics, and third-party advertising are used on ahnafnafee.dev',
+    url: 'https://www.ahnafnafee.dev/privacy-policy',
+    siteName: 'Ahnaf An Nafee',
+    images: [
+      {
+        url: PRIVACY_OG_IMAGE,
+        width: 1200,
+        height: 600,
+        alt: 'Privacy Policy - Ahnaf An Nafee'
+      }
+    ],
+    locale: 'en_US',
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Privacy Policy - Ahnaf An Nafee',
+    description: 'How cookies, analytics, and third-party advertising are used on ahnafnafee.dev',
+    site: '@ahnaf_nafee',
+    creator: '@ahnaf_nafee',
+    images: [PRIVACY_OG_IMAGE]
+  }
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className='layout'>
+      <div className='mx-auto max-w-4xl py-8'>
+        <h1 className='mb-8 text-3xl font-bold tracking-tight text-black md:text-4xl dark:text-white'>
+          Privacy Policy
+        </h1>
+
+        <div className='prose prose-gray dark:prose-invert max-w-none'>
+          <section className='mb-8'>
+            <p className='mb-4'>
+              This Privacy Policy explains what information is collected when you visit <code>ahnafnafee.dev</code> (the
+              &ldquo;Site&rdquo;), how it is used, and the choices you have. This is a personal portfolio and blog
+              operated by {SITE_AUTHOR.name}. By using the Site, you consent to the practices described here.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Information I Collect</h2>
+            <p className='mb-4'>
+              I do not ask you to create an account and I do not directly collect personal information such as your name
+              or address just for browsing. The Site does collect limited data automatically and through the third-party
+              services below:
+            </p>
+            <ul className='mb-4 list-disc pl-6'>
+              <li>
+                <strong>Usage and device data</strong> — pages visited, referring page, approximate location, browser
+                type, and device information, gathered by the analytics providers described below.
+              </li>
+              <li>
+                <strong>Cookies and similar technologies</strong> — small files stored by your browser, used by
+                advertising and analytics partners (see below).
+              </li>
+              <li>
+                <strong>Information you choose to send</strong> — if you email me or post a comment, I receive whatever
+                you include (for example, your email address or GitHub username).
+              </li>
+            </ul>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Cookies and Web Beacons</h2>
+            <p className='mb-4'>
+              The Site uses cookies to store visitor preferences and to record data for the third-party services below.
+              You can disable cookies through your browser settings; doing so does not prevent you from reading the
+              Site, though some features may behave differently.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Advertising — Google AdSense</h2>
+            <p className='mb-4'>
+              This Site displays ads served by Google AdSense, a third-party advertising vendor. Google and its partners
+              use cookies (including the DoubleClick DART cookie) to serve ads based on your prior visits to this Site
+              and other sites on the internet.
+            </p>
+            <ul className='mb-4 list-disc pl-6'>
+              <li>
+                Google&rsquo;s use of advertising cookies enables it and its partners to serve ads to you based on your
+                visits to this and other websites.
+              </li>
+              <li>
+                You may opt out of personalized advertising by visiting{' '}
+                <a
+                  href='https://www.google.com/settings/ads'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  Google Ads Settings
+                </a>
+                .
+              </li>
+              <li>
+                You can opt out of third-party vendor cookies for personalized advertising at{' '}
+                <a
+                  href='https://www.aboutads.info/choices/'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  aboutads.info/choices
+                </a>
+                .
+              </li>
+              <li>
+                For more detail, see{' '}
+                <a
+                  href='https://policies.google.com/technologies/partner-sites'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  How Google uses information from sites that use its services
+                </a>
+                .
+              </li>
+            </ul>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Analytics</h2>
+            <p className='mb-4'>
+              The Site uses the following analytics services to understand traffic and performance:
+            </p>
+            <ul className='mb-4 list-disc pl-6'>
+              <li>
+                <strong>Google Analytics</strong> — measures aggregate traffic and usage. Google&rsquo;s handling of
+                this data is governed by the{' '}
+                <a
+                  href='https://policies.google.com/privacy'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  Google Privacy Policy
+                </a>
+                .
+              </li>
+              <li>
+                <strong>Vercel Analytics and Speed Insights</strong> — privacy-friendly, aggregated performance and
+                traffic metrics collected by the Site&rsquo;s host, Vercel. See the{' '}
+                <a
+                  href='https://vercel.com/legal/privacy-policy'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-primary-600 hover:text-primary-700'
+                >
+                  Vercel Privacy Policy
+                </a>
+                .
+              </li>
+            </ul>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Comments</h2>
+            <p className='mb-4'>
+              Blog comments are powered by Giscus, which stores discussions in GitHub Discussions. To comment you sign
+              in with a GitHub account, and any comment you post is public. This processing is governed by the{' '}
+              <a
+                href='https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='text-primary-600 hover:text-primary-700'
+              >
+                GitHub Privacy Statement
+              </a>
+              .
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Images and Media</h2>
+            <p className='mb-4'>
+              Images are delivered through the ImageKit content delivery network and, in some posts, embedded YouTube
+              videos. These providers may receive your IP address and standard request data in order to serve content.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>External Links</h2>
+            <p className='mb-4'>
+              The Site links to external websites that I do not control. This Privacy Policy does not apply to those
+              sites, and I encourage you to review their privacy policies.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Children&rsquo;s Privacy</h2>
+            <p className='mb-4'>
+              The Site is not directed to children under the age of 13, and I do not knowingly collect personal
+              information from children. If you believe a child has provided such information, please contact me and I
+              will remove it.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Your Choices</h2>
+            <ul className='mb-4 list-disc pl-6'>
+              <li>Adjust or block cookies through your browser settings.</li>
+              <li>Opt out of personalized ads using the links in the Advertising section above.</li>
+              <li>Use browser privacy extensions or &ldquo;Do Not Track&rdquo; signals as you prefer.</li>
+              <li>Contact me to ask what information you have sent me directly and to request its deletion.</li>
+            </ul>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Changes to This Policy</h2>
+            <p className='mb-4'>
+              I may update this Privacy Policy from time to time. Changes take effect when posted on this page, and the
+              &ldquo;Last Updated&rdquo; date below reflects the latest revision.
+            </p>
+          </section>
+
+          <section className='mb-8'>
+            <h2 className='mb-4 text-2xl font-semibold'>Contact</h2>
+            <div className='rounded-lg bg-gray-50 p-4 dark:bg-gray-800'>
+              <p>
+                <strong>Email:</strong>{' '}
+                <a href={`mailto:${SITE_AUTHOR.email}`} className='text-primary-600 hover:text-primary-700'>
+                  {SITE_AUTHOR.email}
+                </a>
+              </p>
+              <p>
+                <strong>Last Updated:</strong> July 2026
+              </p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/src/components/site/common/Footer.tsx
+++ b/src/components/site/common/Footer.tsx
@@ -3,7 +3,7 @@
 import { FooterSocialHome } from '@/components/site/common/FooterSocialHome'
 import { UnstyledLink } from '@/components/site/links'
 
-import APP_ROUTE from '@/libs/constants/route'
+import APP_ROUTE, { SITE_LINKS } from '@/libs/constants/route'
 import { twclsx } from '@/libs/twclsx'
 
 import { usePathname } from 'next/navigation'
@@ -32,8 +32,18 @@ export const Footer: React.FunctionComponent = () => {
             </UnstyledLink>
           ))}
         </div>
-        {/*Empty Column*/}
-        <div></div>
+        <div className='flex flex-col space-y-4'>
+          <p className={'text-sm font-bold'}>SITE</p>
+          {SITE_LINKS.map((route) => (
+            <UnstyledLink
+              href={route.path}
+              key={`footer-${route.path}`}
+              className='hover:border-b-theme-500 max-w-max border-b border-dashed border-transparent text-sm font-medium text-gray-400 hover:text-gray-600'
+            >
+              {route.name}
+            </UnstyledLink>
+          ))}
+        </div>
         <FooterSocialHome />
       </div>
       <hr className='mb-4 w-full border-1 border-gray-200 dark:border-gray-800' />

--- a/src/data/blog/doi-paper-scraper.mdx
+++ b/src/data/blog/doi-paper-scraper.mdx
@@ -20,7 +20,7 @@ keywords:
     'markdown knowledge base'
   ]
 thumbnail: 'https://ik.imagekit.io/8ieg70pvks/blog/doi-to-markdown.png?updatedAt=1778868186651'
-related: []
+related: ['local-llm-pdf-ocr', 'autograder-architecture', 'gofile-upload-github-action']
 ---
 
 Academic reading workflows are still too fragmented. Some papers are easy to access through DOI landing pages, others are only available as PDFs, and note-taking usually becomes a manual copy-paste process.

--- a/src/data/blog/local-llm-pdf-ocr.mdx
+++ b/src/data/blog/local-llm-pdf-ocr.mdx
@@ -52,7 +52,7 @@ keywords:
     'fastapi ocr'
   ]
 thumbnail: 'https://ik.imagekit.io/8ieg70pvks/blog/local-llm-pdf-ocr.png?updatedAt=1778868186537'
-related: []
+related: ['doi-paper-scraper', 'modelfile-syntax-extension', 'autograder-architecture']
 ---
 
 <figure className='not-prose my-6'>

--- a/src/data/blog/modelfile-syntax-extension.mdx
+++ b/src/data/blog/modelfile-syntax-extension.mdx
@@ -45,7 +45,7 @@ keywords:
     'cross-editor extension'
   ]
 thumbnail: 'https://ik.imagekit.io/8ieg70pvks/blog/modelfile-syntax-extension.png?updatedAt=1778868186426'
-related: []
+related: ['local-llm-pdf-ocr', 'gofile-upload-github-action', 'bookworm-privacy-first-library']
 ---
 
 I run a lot of GGUFs locally. Custom system prompts, sampling parameters, conversation primers — all expressed in Ollama Modelfiles. VSCode treated them as plain text: typos in `PARAMETER` names got silently ignored, single-quote `SYSTEM` prompts truncated at the first newline, and `num_ctx` quietly defaulted to 2048 even on models with 32K windows.

--- a/src/data/blog/songmirror-playlist-sync.mdx
+++ b/src/data/blog/songmirror-playlist-sync.mdx
@@ -63,7 +63,7 @@ keywords:
     'fastapi react app'
   ]
 thumbnail: 'https://ik.imagekit.io/8ieg70pvks/blog/spotify-playlist-mirror-sync.png?updatedAt=1783792638037'
-related: []
+related: ['gofile-upload-github-action', 'doi-paper-scraper', 'bookworm-privacy-first-library']
 ---
 
 I curate playlists on Spotify but listen everywhere else: Apple Music in the car, YouTube Music for indie uploads, and a Jellyfin server at home when I want the files to be mine. Keeping them identical by hand is a chore you do once and abandon, so I built [SongMirror](https://github.com/ahnafnafee/songmirror). It's now a self-hosted web app: connect Spotify, Apple Music, YouTube Music, and Jellyfin in the browser, build any number of syncs, and run one-off transfers between services. By default it's a one-way mirror with a source of truth (add a song and it appears everywhere in date-added order, remove one and it disappears everywhere), behind safety rails a bad API response can't get past. Flip on N-way mode and every provider becomes a read-write peer. ISRC-first matching, Docker or a headless CLI. Python, MIT.

--- a/src/libs/constants/resume.ts
+++ b/src/libs/constants/resume.ts
@@ -13,7 +13,7 @@ export const HEADLINE = {
 export const LINKS: typeof SOCIAL = [
   ...SOCIAL.filter((s) => s.title !== 'Telegram'),
   {
-    href: 'https://ahnafnafee.dev',
+    href: 'https://www.ahnafnafee.dev',
     title: 'Website'
   },
   {

--- a/src/libs/constants/route.ts
+++ b/src/libs/constants/route.ts
@@ -21,6 +21,28 @@ const APP_ROUTE = [
   }
 ]
 
+// Footer-only utility/legal links. Kept out of APP_ROUTE so they don't clutter
+// the primary top navigation or the SiteNavigationElement schema, while staying
+// crawlable and visible on every page.
+export const SITE_LINKS = [
+  {
+    path: '/about',
+    name: 'About'
+  },
+  {
+    path: '/contact',
+    name: 'Contact'
+  },
+  {
+    path: '/privacy-policy',
+    name: 'Privacy Policy'
+  },
+  {
+    path: '/security-policy',
+    name: 'Security Policy'
+  }
+]
+
 export const ADDT_ROUTE = [
   // {
   //   path: '/tags',


### PR DESCRIPTION
## Summary

- Add the trust pages AdSense's "low value content" review requires: an accurate privacy policy (AdSense/GA4/Vercel/Giscus/ImageKit disclosures), about, and contact — linked from a new footer column
- Clean up the ~30 URLs Search Console declined to index: noindex the 46 thin topic pages and /offline, drop them from the sitemap (83 → 36 URLs, all real content), 301 the retired /snippet route to /blog, and fix a non-canonical (apex-host) internal link
- Enable ads consent: Consent Mode v2 region-scoped defaults (EEA/UK/CH) so the published Google CMP message gates GA4/ad storage, plus CSP additions (*.gstatic.com, *.doubleclick.net) per Google's publisher guidance
- Fill empty related arrays on four posts so every post renders internal Related Posts links

## Test plan

- [x] yarn type-check, yarn lint, yarn test (60/60) pass
- [x] yarn build green; /about, /contact, /privacy-policy prerender as static
- [x] Prerendered HTML verified: topic pages emit noindex,follow; /offline emits noindex,nofollow; blog posts unrestricted; consent defaults precede gtag config on every page
- [x] Regenerated sitemap contains the three new pages and excludes topic leaves + /offline
- [ ] After deploy: verify consent banner from an EU exit and that /privacy-policy resolves, then run the indexing helper and request AdSense review after recrawl (~3–7 days)