### PR TITLE
fix(seo): allow /api/og in robots.txt so og:image is crawlable

### DIFF
--- a/custom-next-sitemap.js
+++ b/custom-next-sitemap.js
@@ -116,7 +116,11 @@ module.exports = {
     policies: [
       // Single combined wildcard record so crawlers that only honor the first
       // matching User-agent don't miss the Disallow directives.
-      { userAgent: '*', allow: '/', disallow: ['/api/', '/_next/', '/static/'] },
+      // `/api/og` is carved out of the `/api/` block: it backs every og:image
+      // meta tag, so blocking it makes Google report each social card as
+      // "Blocked by robots.txt" and skip it for rich results. Longest-match
+      // wins in Google/Bing, so the Allow overrides the broader Disallow.
+      { userAgent: '*', allow: ['/', '/api/og'], disallow: ['/api/', '/_next/', '/static/'] },
       // AI / LLM crawlers — explicitly allow each so they don't fall back to
       // wildcard rules and so we have a single source of truth.
       { userAgent: 'GPTBot', allow: '/' },

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 # *
 User-agent: *
 Allow: /
+Allow: /api/og
 Disallow: /api/
 Disallow: /_next/
 Disallow: /static/

--- a/scripts/validate-sitemap.js
+++ b/scripts/validate-sitemap.js
@@ -102,17 +102,28 @@ if (origins.has('http://localhost:3000') || [...origins].some((o) => o.includes(
 // robots.txt is committed while the sitemap is generated, so the two drift
 // independently. A Sitemap: line pointing at the wrong host is invisible until a
 // crawler follows it.
-if (fs.existsSync(robotsFile) && origins.size === 1) {
+if (fs.existsSync(robotsFile)) {
   const robots = fs.readFileSync(robotsFile, 'utf8')
-  const declared = [...robots.matchAll(/^\s*Sitemap:\s*(\S+)\s*$/gim)].map((m) => m[1])
-  if (declared.length === 0) fail(`${rel(robotsFile)} declares no Sitemap: line.`)
-  for (const entry of declared) {
-    try {
-      if (new URL(entry).origin !== [...origins][0]) {
-        fail(`${rel(robotsFile)} points at ${entry}, but the sitemap uses ${[...origins][0]}.`)
+
+  // /api/og renders every og:image. It sits under the broader `/api/` Disallow,
+  // so it needs an explicit Allow carve-out (longest-match wins in Google/Bing).
+  // Without it, Google silently reports each social card as "Blocked by
+  // robots.txt" and skips it for rich results.
+  if (!/^\s*Allow:\s*\/api\/og\s*$/im.test(robots)) {
+    fail(`${rel(robotsFile)} is missing "Allow: /api/og". og:image URLs fall under the /api/ Disallow.`)
+  }
+
+  if (origins.size === 1) {
+    const declared = [...robots.matchAll(/^\s*Sitemap:\s*(\S+)\s*$/gim)].map((m) => m[1])
+    if (declared.length === 0) fail(`${rel(robotsFile)} declares no Sitemap: line.`)
+    for (const entry of declared) {
+      try {
+        if (new URL(entry).origin !== [...origins][0]) {
+          fail(`${rel(robotsFile)} points at ${entry}, but the sitemap uses ${[...origins][0]}.`)
+        }
+      } catch {
+        fail(`${rel(robotsFile)} has an unparseable Sitemap: entry: ${entry}`)
       }
-    } catch {
-      fail(`${rel(robotsFile)} has an unparseable Sitemap: entry: ${entry}`)
     }
   }
 }


### PR DESCRIPTION
## Summary

- `Disallow: /api/` in the wildcard robots.txt record also covered `/api/og`, the endpoint behind every `og:image` meta tag. Search Console flagged the social cards as "Blocked by robots.txt" and skipped them for rich results.
- Added an explicit `Allow: /api/og` carve-out. Google and Bing resolve conflicting rules by longest matching path, so the 7-character Allow overrides the 5-character Disallow while the rest of `/api/` stays blocked.
- Added a `validate-sitemap` guard so the carve-out cannot be dropped silently. CI already runs that script against the build output.

## Notes

- No added crawl cost. `/api/og` already responds with `Cache-Control: public, max-age=31536000, immutable`, so the CDN absorbs crawler hits.
- The AI/LLM crawler records were never affected; each carries `Allow: /` with no disallows.
- The Search Console example URL is on the apex domain, which the existing apex-to-www 301 in `next.config.js` already handles.

## Test plan

- [x] `yarn type-check`
- [x] `yarn lint`
- [x] `yarn test` (66 tests, 10 files)
- [x] `yarn build`
- [x] `yarn validate:sitemap` against build output (36 URLs, 31 images)
- [x] `yarn validate:json-ld` (291 blocks across 85 files)
- [x] `yarn validate:icons`
- [x] New guard verified both directions: exit 1 with the Allow line removed, exit 0 with it present
- [ ] After deploy: confirm `/robots.txt` serves the Allow line, then hit "Validate Fix" in Search Console

## Reference

Google's robots.txt spec: "crawlers use the most specific rule based on the length of the rule path." Their own example is `allow: /p` winning over `disallow: /`. Query strings are included in path matching, so `/api/og?title=...` matches the carve-out.